### PR TITLE
Use jest's toMatchSnapshot()

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "axios": "^0.13.1",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
+    "jest": "^14.1.0",
     "lodash": "^4.14.0",
     "moment": "^2.12.0",
     "normalizr": "^2.2.1",

--- a/src/components/Label/__tests__/Label-test.js
+++ b/src/components/Label/__tests__/Label-test.js
@@ -6,19 +6,15 @@ import Label from 'src/components/Label';
 
 describe('Label', () => {
   it('should render its title', () => {
-    const el = shallow(<Label title="foo" />);
-    expect(el.children().text()).toEqual("foo")
+    expect(<Label title="foo" />).toMatchSnapshot();
   });
 
-  fit('should support style overriding', () => {
-    const el = shallow(
+  it('should support style overriding', () => {
+    expect(
       <Label
         title="foo"
         style={{fontSize: 23}}
-      />);
-
-      expect(el.props()).toEqual(jasmine.objectContaining({
-        style: jasmine.arrayContaining([{fontSize: 23}])
-      }))
+      />
+    ).toMatchSnapshot()
   });
 });

--- a/src/components/Label/__tests__/__snapshots__/Label-test.js.snap
+++ b/src/components/Label/__tests__/__snapshots__/Label-test.js.snap
@@ -1,0 +1,30 @@
+exports[`Label should render its title 0`] = `
+Object {
+  "$$typeof": Symbol(react.element),
+  "_owner": null,
+  "_store": Object {},
+  "key": null,
+  "props": Object {
+    "title": "foo"
+  },
+  "ref": null,
+  "type": [Function Label]
+}
+`;
+
+exports[`Label should support style overriding 0`] = `
+Object {
+  "$$typeof": Symbol(react.element),
+  "_owner": null,
+  "_store": Object {},
+  "key": null,
+  "props": Object {
+    "style": Object {
+      "fontSize": 23
+    },
+    "title": "foo"
+  },
+  "ref": null,
+  "type": [Function Label]
+}
+`;


### PR DESCRIPTION
We'd like to use this feature for testing that our components render their given properties according to what we've visually confirmed (and continue to as the codebase changes over time).

The plan is to require PRs with components and snapshot tests to have corresponding screenshots of the cases we are testing, to ensure that we have in fact visually confirmed that these cases are working as expected.