### PR TITLE
Remove unnecessary initialState() function

### DIFF
--- a/src/stores/__tests__/helpers-test.js
+++ b/src/stores/__tests__/helpers-test.js
@@ -1,12 +1,10 @@
 import { getContext } from 'src/stores/helpers';
-import initialState from 'src/stores/initialState';
 
 
 describe('helpers', () => {
   describe('getContext', () => {
     it('should get auth details', () => {
       expect(getContext({
-        ...initialState(),
         auth: {
           email: 'a@b.org',
           password: '1337',

--- a/src/stores/configureStore.js
+++ b/src/stores/configureStore.js
@@ -7,7 +7,6 @@ import { getAuthorizationToken as getAuthorizationHeaderValue } from 'src/config
 
 import auth from 'src/auth/reducer';
 import { getContext } from 'src/stores/helpers';
-import initialState from 'src/stores/initalState';
 import contextMiddleware from 'src/contextMiddleware';
 
 const httpRequestMiddleware = new HTTPRequestMiddleware({
@@ -27,10 +26,10 @@ const rootReducer = combineReducers({
   auth,
 });
 
-export default function configureStore() {
+export default function configureStore(initialState = {}) {
   return createStore(
     rootReducer,
-    initialState(),
+    initialState,
     applyMiddleware(
       thunkMiddleware,
       httpRequestMiddleware.apply,

--- a/src/stores/initialState.js
+++ b/src/stores/initialState.js
@@ -1,6 +1,0 @@
-const initialState = () => ({
-  auth: null,
-});
-
-
-export default initialState;


### PR DESCRIPTION
I was initially thinking that `initialState()` would be a sensible place to define the initial values, but the defining the initial state in each reducer makes more sense.