### PR TITLE
Change entity reducer to use a defined set of 'entity actions'

### DIFF
--- a/src/constants/actions.js
+++ b/src/constants/actions.js
@@ -8,4 +8,4 @@ const ACTIONS_WITH_ENTITIES = [
 
 export {
   ACTIONS_WITH_ENTITIES,
-}
+};

--- a/src/constants/actions.js
+++ b/src/constants/actions.js
@@ -1,0 +1,11 @@
+import { PROFILE_FETCH_SUCCESS } from 'src/profile/constants';
+
+
+const ACTIONS_WITH_ENTITIES = [
+  PROFILE_FETCH_SUCCESS,
+];
+
+
+export {
+  ACTIONS_WITH_ENTITIES,
+}

--- a/src/reducers/__tests__/test-entities.js
+++ b/src/reducers/__tests__/test-entities.js
@@ -1,0 +1,45 @@
+jest.mock('src/constants/actions', () => ({
+  __esModule: true,
+  ACTIONS_WITH_ENTITIES: ['ACTION_WITH_ENTITIES']
+}));
+
+import reduce from 'src/reducers/entities';
+
+
+describe('reducers/entities', () => {
+  it('should be a noop for actions without entities', () => {
+    expect(reduce({
+      vogons: { 23: { id: 23 } },
+    }, {
+      type: 'ACTION_WITHOUT_ENTITIES',
+    })).toEqual({
+      vogons: { 23: { id: 23 } },
+    });
+  });
+
+  it('should merge entities contained in an action', () => {
+    expect(reduce({
+      vogons: { 23: { id: 23 } },
+    }, {
+      type: 'ACTION_WITH_ENTITIES',
+      payload: {
+        entities: {
+          mice: {
+            3: { id: 3 },
+          },
+          vogons: {
+            21: { id: 21 },
+          },
+        },
+      },
+    })).toEqual({
+      mice: {
+        3: { id: 3 },
+      },
+      vogons: {
+        21: { id: 21 },
+        23: { id: 23 },
+      },
+    });
+  });
+});

--- a/src/reducers/__tests__/test-entities.js
+++ b/src/reducers/__tests__/test-entities.js
@@ -1,6 +1,6 @@
 jest.mock('src/constants/actions', () => ({
   __esModule: true,
-  ACTIONS_WITH_ENTITIES: ['ACTION_WITH_ENTITIES']
+  ACTIONS_WITH_ENTITIES: ['ACTION_WITH_ENTITIES'],
 }));
 
 import reduce from 'src/reducers/entities';

--- a/src/reducers/entities.js
+++ b/src/reducers/entities.js
@@ -1,0 +1,12 @@
+import merge from 'lodash/merge';
+
+
+const entitiesReducer = (state = {}, action) => {
+  if (action.payload && action.payload.entities) {
+    return merge(state, action.payload.entities);
+  }
+  return state;
+};
+
+
+export default entitiesReducer;

--- a/src/reducers/entities.js
+++ b/src/reducers/entities.js
@@ -1,12 +1,11 @@
+import { includes } from 'lodash';
 import merge from 'lodash/merge';
+import { ACTIONS_WITH_ENTITIES } from 'src/constants/actions';
 
 
-const entitiesReducer = (state = {}, action) => {
-  if (action.payload && action.payload.entities) {
-    return merge(state, action.payload.entities);
-  }
-  return state;
-};
+const entitiesReducer = (state, action) => includes(ACTIONS_WITH_ENTITIES, action.type)
+  ? merge(state, action.payload.entities)
+  : state;
 
 
 export default entitiesReducer;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,0 +1,12 @@
+import { combineReducers } from 'redux';
+import entities from 'src/reducers/entities';
+import auth from 'src/auth/reducer';
+
+
+const rootReducer = combineReducers({
+  entities,
+  auth,
+});
+
+
+export default rootReducer;

--- a/src/stores/configureStore.js
+++ b/src/stores/configureStore.js
@@ -1,29 +1,16 @@
-import { createStore, combineReducers, applyMiddleware } from 'redux';
+import { createStore, applyMiddleware } from 'redux';
 import thunkMiddleware from 'redux-thunk';
-import merge from 'lodash/merge';
 
 import HTTPRequestMiddleware from './HTTPRequestMiddleware';
 import { getAuthorizationToken as getAuthorizationHeaderValue } from 'src/configuration';
 
-import auth from 'src/auth/reducer';
 import { getContext } from 'src/stores/helpers';
 import contextMiddleware from 'src/stores/contextMiddleware';
+import rootReducer from 'src/reducers';
+
 
 const httpRequestMiddleware = new HTTPRequestMiddleware({
   getAuthorizationHeaderValue,
-});
-
-
-const entities = (state = {}, action) => {
-  if (action.payload && action.payload.entities) {
-    return merge(state, action.payload.entities);
-  }
-  return state;
-};
-
-const rootReducer = combineReducers({
-  entities,
-  auth,
 });
 
 export default function configureStore(initialState = {}) {


### PR DESCRIPTION
At the moment we do this a bit implicitly by inspecting for an `entity` property in the action's payload.

Something like this seems a bit more explicit:

```js
// src/constants.js
const { PROFILE_FETCH_SUCCESS } from 'src/profile/constants';

const ENTITY_ACTIONS = [
  PROFILE_FETCH_SUCCESS,
];

// src/entitites/reducer.js
const reduceEntities = (state, action)) => includes(ENTITY_ACTIONS, action.type)
  ? merge(state, action.payload.entities)
  : state;
```