### PR TITLE
Normalize case for api requests and responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "dependencies": {
     "axios": "^0.13.1",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
+    "camelcase": "^3.0.0",
+    "decamelize": "^1.2.0",
+    "deep-map-keys": "^1.2.0",
     "lodash": "^4.14.0",
     "moment": "^2.12.0",
     "normalizr": "^2.2.1",

--- a/src/api/__tests__/request-test.js
+++ b/src/api/__tests__/request-test.js
@@ -151,7 +151,7 @@ describe('api/request', () => {
       });
     });
 
-    it('support a response data parse function', async () => {
+    it('should support a response data parse function', async () => {
       axios.mockReturnValue(Promise.resolve({ data: { bar: 23 } }));
 
       const res = await request({
@@ -161,6 +161,68 @@ describe('api/request', () => {
       });
 
       expect(res).toEqual(23);
+    });
+
+    it('should support case normalizing', async () => {
+      axios.mockReturnValue(Promise.resolve({
+        data: {
+          foo_bar: [{
+            baz_quux: { corge_grault: 23 },
+          }],
+        },
+      }));
+
+      const res = await request({
+        url: '/foo',
+        method: 'GET',
+        data: {
+          garplyWaldo: {
+            fredXxyyxx: [{
+              lerpLarp: { loremWinrar: 21 },
+            }],
+          },
+        },
+      });
+
+      expect(res).toEqual({
+        fooBar: [{
+          bazQuux: { corgeGrault: 23 },
+        }],
+      });
+
+      expect(axios.mock.calls).toEqual([[
+        jasmine.objectContaining({
+          data: {
+            garply_waldo: {
+              fred_xxyyxx: [{
+                lerp_larp: { lorem_winrar: 21 },
+              }],
+            },
+          },
+        }),
+      ]]);
+    });
+
+    it('should support disabling of case normalizing', async () => {
+      axios.mockReturnValue(Promise.resolve({
+        data: { foo_bar: 23, },
+      }));
+
+      const res = await request({
+        url: '/foo',
+        method: 'GET',
+        data: { garplyWaldo: 21 },
+      });
+
+      expect(res).toEqual({
+        fooBar: 23,
+      });
+
+      expect(axios.mock.calls).toEqual([[
+        jasmine.objectContaining({
+          data: { garply_waldo: 21 },
+        }),
+      ]]);
     });
   });
 

--- a/src/api/__tests__/request-test.js
+++ b/src/api/__tests__/request-test.js
@@ -205,7 +205,7 @@ describe('api/request', () => {
 
     it('should support disabling of case normalizing', async () => {
       axios.mockReturnValue(Promise.resolve({
-        data: { foo_bar: 23, },
+        data: { foo_bar: 23 },
       }));
 
       const res = await request({

--- a/src/api/request.js
+++ b/src/api/request.js
@@ -18,6 +18,24 @@ const serializeAuth = ({ email, password }) => ({
 });
 
 
+const toCamelCase = d => deepMapKeys(d, k => camelCase(k));
+
+
+const toSnakeCase = d => deepMapKeys(d, k => snakeCase(k));
+
+
+const parse = (d, { parseFn, normalizeCase }) => {
+  const res = normalizeCase
+    ? toCamelCase(d)
+    : d;
+
+  return parseFn(res);
+};
+
+
+const serialize = d => toSnakeCase(d);
+
+
 const parseConf = ({
   url,
   method,
@@ -26,7 +44,7 @@ const parseConf = ({
   schema = null,
   params = null,
   normalizeCase = true,
-  parse = identity,
+  parse: parseFn = identity,
   headers = {},
 }) => ({
   parse,
@@ -34,6 +52,8 @@ const parseConf = ({
   schema,
 
   normalizeCase,
+
+  parseFn,
 
   options: omitNulls({
     url: API_URL + url,
@@ -100,24 +120,6 @@ const request = rawConf => {
   return axios(options)
     .then(res => requestSuccess(res, conf), requestFailure);
 };
-
-
-const toCamelCase = d => deepMapKeys(d, k => camelCase(k));
-
-
-const toSnakeCase = d => deepMapKeys(d, k => snakeCase(k));
-
-
-const parse = (d, { parse: parseFn, normalizeCase }) => {
-  const res = normalizeCase
-    ? toCamelCase(d)
-    : d;
-
-  return parseFn(res);
-};
-
-
-const serialize = d => toSnakeCase(d);
 
 
 export default request;


### PR DESCRIPTION
So we don't have snakecase in our camelcase.