### PR TITLE
Check for journey screen's top bar updates every min

### DIFF
--- a/src/actions/__tests__/tick-test.js
+++ b/src/actions/__tests__/tick-test.js
@@ -1,0 +1,28 @@
+import tick from 'src/actions/tick';
+import * as constants from 'src/constants/tick';
+
+jest.useFakeTimers();
+
+
+describe('actions/tick', () => {
+  it('should dispatch a tick action each interval', () => {
+    const dispatch = jest.fn();
+    tick()(dispatch);
+
+    expect(dispatch.mock.calls).toEqual([]);
+
+    jest.runTimersToTime(constants.TICK_INTERVAL);
+
+    expect(dispatch.mock.calls).toEqual([[{
+      type: constants.TICK,
+    }]]);
+
+    jest.runTimersToTime(constants.TICK_INTERVAL);
+
+    expect(dispatch.mock.calls).toEqual([[{
+      type: constants.TICK,
+    }], [{
+      type: constants.TICK,
+    }]]);
+  });
+});

--- a/src/actions/tick.js
+++ b/src/actions/tick.js
@@ -1,0 +1,9 @@
+import * as constants from 'src/constants/tick';
+
+
+const tick = () => dispatch => setInterval(() => dispatch({
+  type: constants.TICK,
+}), constants.TICK_INTERVAL);
+
+
+export default tick;

--- a/src/app.js
+++ b/src/app.js
@@ -2,12 +2,14 @@ import React from 'react';
 import { Provider } from 'react-redux';
 
 import errors from 'src/errors';
+import tick from 'src/actions/tick';
 import configureStore from 'src/stores/configureStore';
 import TopNavigationContainer from 'src/containers/TopNavigationContainer';
 
 
 const store = configureStore();
 errors(store);
+store.dispatch(tick());
 
 
 const App = function App() {

--- a/src/constants/tick.js
+++ b/src/constants/tick.js
@@ -1,0 +1,8 @@
+const TICK_INTERVAL = 1000;
+const TICK = 'TICK';
+
+
+export {
+  TICK,
+  TICK_INTERVAL,
+};

--- a/src/constants/tick.js
+++ b/src/constants/tick.js
@@ -1,4 +1,4 @@
-const TICK_INTERVAL = 1000;
+const TICK_INTERVAL = 1000 * 60;
 const TICK = 'TICK';
 
 

--- a/src/reducers/__tests__/tick-test.js
+++ b/src/reducers/__tests__/tick-test.js
@@ -1,0 +1,21 @@
+import moment from 'moment';
+import reduce, { createInitialState } from 'src/reducers/tick';
+
+
+describe('reducers/tick', () => {
+  describe('TICK', () => {
+    it('should update the tick time', () => {
+      const now = +moment();
+
+      const state = {
+        ...createInitialState(),
+        time: now - 23,
+      };
+
+      expect(reduce(state, { type: 'TICK' })).toEqual({
+        ...createInitialState(),
+        time: now,
+      });
+    });
+  });
+});

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -5,6 +5,7 @@ import navigation from 'src/reducers/navigation';
 import profile from 'src/reducers/profile';
 import onboarding from 'src/reducers/onboarding';
 import callNote from 'src/reducers/callNote';
+import tick from 'src/reducers/tick';
 
 
 const rootReducer = combineReducers({
@@ -14,6 +15,7 @@ const rootReducer = combineReducers({
   auth,
   profile,
   navigation,
+  tick,
 });
 
 

--- a/src/reducers/tick.js
+++ b/src/reducers/tick.js
@@ -1,0 +1,25 @@
+import moment from 'moment';
+import { TICK } from 'src/constants/tick';
+
+
+const createInitialState = () => ({
+  time: +moment(),
+});
+
+
+const tick = (state = createInitialState(), action) => {
+  switch (action.type) {
+    case TICK:
+      return {
+        ...state,
+        time: +moment(),
+      };
+
+    default:
+      return state;
+  }
+};
+
+
+export { createInitialState };
+export default tick;


### PR DESCRIPTION
As of #217, the journey screen's top bar renders a next scheduled call reminder, but switches to show "start call now" (where tapping would allow the user to start the call) if the current time is 1 hour or less before or after the most recent sheduled call time.

We need a way for this bar to update when it should switch to its "start call now" mode.

The plan is to dispatch a tick action every minute, and use this for updating the Journey view. Problem is, react-redux won't simply re-render if an action has been dispatched, since the app's state hasn't changed at all (it seems to do a shallow comparison between the new and old state).

These are the approaches I could think of to work around this:
  1. in a reducer, record the current time each tick and add it to the state
  2. move the logic for computing the most recent scheduled call, as well as whether a call should be started, from the Journey view's container to a reducer

(2) complicates our reducer setup, since its reducer would need access to the entire state to use our store helpers, and since technically this is computable state. It _feels_ like this logic belongs more in a container, so I'm going with approach (1) for now.

Ready for review.