### PR TITLE
Prevent duplicate call notes

### DIFF
--- a/src/actions/__tests__/callNote-test.js
+++ b/src/actions/__tests__/callNote-test.js
@@ -16,7 +16,7 @@ import {
 } from 'src/actionHelpers';
 
 import * as actions from 'src/actions/callNote';
-import { capture, fakeContext, fakeCallNote } from 'app/scripts/helpers';
+import { capture, fakeContext, fakeCallNote, fakeState } from 'app/scripts/helpers';
 
 const { ApiResponseError } = api;
 
@@ -40,6 +40,24 @@ describe('actions/callNote', () => {
         request: staticAction(constants.CALL_NOTE_CREATE_REQUEST),
         success: dataAction(constants.CALL_NOTE_CREATE_SUCCESS),
       }))).toBe(true);
+    });
+  });
+
+  describe('createCallNoteOnce', () => {
+    it('should only create a call note if it isnt already sending', async () => {
+      const state = fakeState();
+      const getState = () => state;
+
+      const ctx = fakeContext();
+      const callNote = fakeCallNote();
+      const fn = d => dispatch => dispatch(d);
+
+      let res = await capture(actions.createCallNoteOnce(callNote, fn), ctx, getState);
+      expect(res).toEqual([callNote]);
+
+      state.callNote.callNote.isSending = true;
+      res = await capture(actions.createCallNoteOnce(callNote, fn), ctx, getState);
+      expect(res).toEqual([]);
     });
   });
 

--- a/src/actions/callNote.js
+++ b/src/actions/callNote.js
@@ -25,11 +25,23 @@ export const createCallNote = apiAction({
 });
 
 
+// TODO remove once we no longer have a duplicates issue
+export const createCallNoteOnce = (callNote, fn = createCallNote) => {
+  return (dispatch, ctx, getState) => {
+    const { callNote: { callNote: { isSending } } } = getState();
+    if (!isSending) return fn(callNote)(dispatch, ctx, getState);
+    else return null;
+  };
+};
+
+
 // TODO remove once api doesn't need client side to figure out mentor id
-export const createCallNoteWithMentor = (data, fn = createCallNote) => (dispatch, ctx) => fn({
-  ...data,
-  mentor: ctx.profile.id,
-})(dispatch, ctx);
+export const createCallNoteWithMentor = (data, fn = createCallNoteOnce) => {
+  return (dispatch, ctx, ...xargs) => fn({
+    ...data,
+    mentor: ctx.profile.id,
+  })(dispatch, ctx, ...xargs);
+};
 
 
 export const updateCallNote = apiAction({

--- a/src/reducers/__tests__/callNote-test.js
+++ b/src/reducers/__tests__/callNote-test.js
@@ -21,4 +21,14 @@ describe('reducers/callNote', () => {
         .toEqual(reduce(void 0, { type: 'FAKE' }));
     });
   });
+
+  describe('CALL_NOTE_CREATE_REQUEST', () => {
+    it('should mark the call note as sending', () => {
+      const { callNote: { isSending } } = reduce(void 0, {
+        type: 'CALL_NOTE_CREATE_REQUEST',
+      });
+
+      expect(isSending).toBe(true);
+    });
+  });
 });

--- a/src/reducers/callNote.js
+++ b/src/reducers/callNote.js
@@ -11,6 +11,13 @@ const navigation = makeStepperNavigationReducer({
 
 const callNote = (state = {}, action) => {
   switch (action.type) {
+    // TODO remove once we no longer have a duplicates issue
+    case constants.CALL_NOTE_CREATE_REQUEST:
+      return {
+        ...state,
+        isSending: true,
+      };
+
     case constants.CALL_NOTES_CHANGE_CALL_NOTE:
       return {
         ...state,


### PR DESCRIPTION
It seems we still have a duplicate call notes issue. This is still a workaround, but prevents duplicate call notes since this is a change at the action layer, rather than the view layer.

Fixing this properly involves quite a bit of refactoring and cleanup, of which #246 is the start, but we need this fixed sooner than that.

@smn @Mitso @projectmushroom ready for review