### PR TITLE
Scheduled call event view

### DIFF
--- a/src/containers/ScheduledCallEventContainer.js
+++ b/src/containers/ScheduledCallEventContainer.js
@@ -1,31 +1,20 @@
-import moment from 'moment';
 import { connect } from 'react-redux';
-import { Event } from 'src/components';
-import images from 'src/constants/images';
+import ScheduledCallEvent from 'src/views/ScheduledCallEvent';
 import { getScheduledCall, getScheduledCallActivity } from 'src/store/helpers';
 
 
 const mapStateToProps = (state, {
   objectId: scheduledCallId,
-  eventType: type,
-  occuredAt: date,
 }) => {
   const scheduledCall = getScheduledCall(state, scheduledCallId);
   const activity = getScheduledCallActivity(state, scheduledCallId);
-  let icon = images.JOURNEY_EVENT_SCHEDULED_CALL_ICON;
-  if (activity && activity.icon) {
-    icon = { uri: activity.icon };
-  }
 
   return {
-    type,
-    date,
-    icon,
-    title: 'Call scheduled',
-    blurb: moment(scheduledCall.callTime).format('dddd Do, MMMM YYYY h:mm a'),
+    activity,
+    scheduledCall,
   };
 };
 
 
 export { mapStateToProps };
-export default connect(mapStateToProps)(Event);
+export default connect(mapStateToProps)(ScheduledCallEvent);

--- a/src/containers/__tests__/ScheduledCallEventContainer-tests.js
+++ b/src/containers/__tests__/ScheduledCallEventContainer-tests.js
@@ -1,62 +1,45 @@
 import { mapStateToProps } from 'src/containers/ScheduledCallEventContainer';
-import { fakeState, fakeEvent, fakeScheduledCall, fakeActivity } from 'app/scripts/helpers';
-import images from 'src/constants/images';
-import { EVENT_TYPE_SCHEDULED_CALL_CREATED } from 'src/constants/events';
+import { fakeState, fakeScheduledCall, fakeActivity } from 'app/scripts/helpers';
 
 
 describe('CallScheduledEventContainer', () => {
   describe('mapStateToProps', () => {
-    it('should provide the activities icon', () => {
+    it('should provide the scheduled call', () => {
+      const scheduledCall = fakeScheduledCall({ id: 21 });
+
       const state = fakeState({
         entities: {
-          activities: {
-            110: fakeActivity({
-              id: 110,
-              icon: 'http://icons.are.a.cool.way.to.communicate',
-            }),
-          },
           scheduledCalls: {
-            55: fakeScheduledCall({
-              id: 55,
-              activity: 110,
-              callTime: '2016-11-11T12:00Z',
-            }),
+            21: scheduledCall,
           },
         },
       });
-      expect(mapStateToProps(state, fakeEvent({
-        eventType: EVENT_TYPE_SCHEDULED_CALL_CREATED,
-        objectId: 55, // scheduledCall
-      }))).toEqual({
-        type: EVENT_TYPE_SCHEDULED_CALL_CREATED,
-        date: '2016-09-16T11:19:17.368442Z',
-        icon: { uri: 'http://icons.are.a.cool.way.to.communicate' },
-        title: 'Call scheduled',
-        blurb: 'Friday 11th, November 2016 2:00 pm',
-      });
+
+      expect(mapStateToProps(state, { objectId: 21 }))
+        .toEqual(jasmine.objectContaining({ scheduledCall }));
     });
 
-    it('should fall back to the default icon when no activity is specified', () => {
+    it('should provide the activity', () => {
+      const activity = fakeActivity({ id: 23 });
+
+      const scheduledCall = fakeScheduledCall({
+        id: 21,
+        activity: 23,
+      });
+
       const state = fakeState({
         entities: {
           scheduledCalls: {
-            55: fakeScheduledCall({
-              id: 55,
-              callTime: '2016-11-11T12:00Z',
-            }),
+            21: scheduledCall,
+          },
+          activities: {
+            23: activity,
           },
         },
       });
-      expect(mapStateToProps(state, fakeEvent({
-        eventType: EVENT_TYPE_SCHEDULED_CALL_CREATED,
-        objectId: 55, // scheduledCall
-      }))).toEqual({
-        type: EVENT_TYPE_SCHEDULED_CALL_CREATED,
-        date: '2016-09-16T11:19:17.368442Z',
-        icon: images.JOURNEY_EVENT_SCHEDULED_CALL_ICON,
-        title: 'Call scheduled',
-        blurb: 'Friday 11th, November 2016 2:00 pm',
-      });
+
+      expect(mapStateToProps(state, { objectId: 21 }))
+        .toEqual(jasmine.objectContaining({ activity }));
     });
   });
 });

--- a/src/views/ScheduledCallEvent/__tests__/ScheduledCallEvent-test.js
+++ b/src/views/ScheduledCallEvent/__tests__/ScheduledCallEvent-test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import images from 'src/constants/images';
+import ScheduledCallEvent from 'src/views/ScheduledCallEvent';
+import { fakeScheduledCall, fakeActivity } from 'app/scripts/helpers';
+
+
+describe('ScheduledCallEvent', () => {
+  const createComponent = (props = {}) => (
+    <ScheduledCallEvent
+      scheduledCall={fakeScheduledCall()}
+      {...props}
+    />
+  );
+
+  it('should render', () => {
+    const el = render(createComponent());
+    expect(el.toJSON()).toMatchSnapshot();
+  });
+
+  it('should display an activity icon if an activity with an icon is given', () => {
+    let el;
+
+    el = shallow(createComponent({ activity: void 0 }));
+
+    expect(el.find('Event').prop('icon'))
+      .toEqual(images.JOURNEY_EVENT_SCHEDULED_CALL_ICON);
+
+    el = shallow(createComponent({ activity: fakeActivity({ icon: void 0 }) }));
+
+    expect(el.find('Event').prop('icon'))
+      .toEqual(images.JOURNEY_EVENT_SCHEDULED_CALL_ICON);
+
+    el = shallow(createComponent({
+      activity: fakeActivity({ icon: 'http://placehold.it/56x56' }),
+    }));
+
+    expect(el.find('Event').prop('icon'))
+      .toEqual({ uri: 'http://placehold.it/56x56' });
+  });
+});

--- a/src/views/ScheduledCallEvent/__tests__/__snapshots__/ScheduledCallEvent-test.js.snap
+++ b/src/views/ScheduledCallEvent/__tests__/__snapshots__/ScheduledCallEvent-test.js.snap
@@ -1,0 +1,31 @@
+exports[`ScheduledCallEvent should render 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#ffbcbc",
+        "borderColor": "red",
+        "borderWidth": 1,
+        "height": 100,
+        "justifyContent": "center",
+        "margin": 10,
+        "width": 300,
+      },
+      undefined,
+    ]
+  }>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Object {
+        "color": "#333333",
+        "margin": 20,
+      }
+    }>
+    TouchableNativeFeedback is not supported on this platform!
+  </Text>
+</View>
+`;

--- a/src/views/ScheduledCallEvent/index.js
+++ b/src/views/ScheduledCallEvent/index.js
@@ -1,0 +1,34 @@
+import moment from 'moment';
+import React, { PropTypes } from 'react';
+import { Event } from 'src/components';
+import images from 'src/constants/images';
+
+
+const ScheduledCallEvent = ({
+  activity,
+  scheduledCall: { callTime },
+}) => (
+  <Event
+    date={callTime}
+    icon={
+      activity && activity.icon
+        ? { uri: activity.icon }
+        : images.JOURNEY_EVENT_SCHEDULED_CALL_ICON
+    }
+    title="Call scheduled"
+    blurb={moment(callTime).format('dddd Do, MMMM YYYY h:mm a')}
+  />
+);
+
+
+ScheduledCallEvent.propTypes = {
+  activity: PropTypes.shape({
+    icon: PropTypes.any,
+  }),
+  scheduledCall: PropTypes.shape({
+    callTime: PropTypes.string,
+  }),
+};
+
+
+export default ScheduledCallEvent;


### PR DESCRIPTION
At the moment the view details are in the container, we should move these into a view so that the container is only providing the relevant data.

@smn @Mitso @projectmushroom ready for review