### PR TITLE
Allow version suffixes when reading package.json version in build.gradle

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -92,8 +92,8 @@ android {
         applicationId "org.praekelt.mentorship"
         minSdkVersion 16
         targetSdkVersion 22
-        versionCode versionMajor * 10000 + versionMinor * 100 + versionPatch
-        versionName "${versionMajor}.${versionMinor}.${versionPatch}"
+        versionCode npmVersion[0] * 10000 + npmVersion[1] * 100 + npmVersion[2]
+        versionName npmVersionName
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,10 +30,8 @@ subprojects {
     }
 
     ext {
-        def npmVersion = getNpmVersionArray()
-        versionMajor = npmVersion[0]
-        versionMinor = npmVersion[1]
-        versionPatch = npmVersion[2]
+        npmVersionName = getNpmVersionName()
+        npmVersion = getNpmVersionArray()
     }
 }
 
@@ -49,13 +47,13 @@ allprojects {
 }
 
 
-def getNpmVersion() {
+def getNpmVersionName() {
     def inputFile = new File("../package.json")
     def packageJson = new JsonSlurper().parseText(inputFile.text)
     return packageJson["version"]
 }
 
-def getNpmVersionArray() { // major [0], minor [1], patch [2]
-    def (major, minor, patch) = getNpmVersion().tokenize('.')
+def getNpmVersionArray() {
+    def (major, minor, patch) = getNpmVersionName().minus(~/-.*/).tokenize('.')
     return [Integer.parseInt(major), Integer.parseInt(minor), Integer.parseInt(patch)] as int[]
 }


### PR DESCRIPTION
This will allow us to publish dev releases. The suffixes still can't be taken into account when calculating the version code google play uses, but provided we arent using suffixes outside of development releases, I think this is fine.

@smn ready for review