### PR TITLE
Fix Activity ordering

### DIFF
--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -35,6 +35,7 @@ export const fakeAuth = () => ({
 
 export const fakeCategory = data => ({
   id: 1,
+  ordinal: 1,
   title: 'Level',
   color: '#97c13c',
   about: 'touba',
@@ -46,6 +47,7 @@ export const fakeCategory = data => ({
 
 export const fakeActivity = data => ({
   id: 1,
+  ordinal: 2,
   title: 'Activity 3',
   instructions: 'snoitcrutsni',
   isComplete: false,

--- a/src/api/parse.js
+++ b/src/api/parse.js
@@ -18,6 +18,7 @@ export const parseCategory = ({
   image,
   ...d,
 }) => ({
+  ordinal: null,
   ...d,
   image: imageUrl(image),
 });
@@ -28,6 +29,7 @@ export const parseActivity = ({
   poster,
   icon,
 }) => ({
+  ordinal: null,
   ...d,
   poster: imageUrl(poster),
   icon: imageUrl(icon),

--- a/src/store/__tests__/helpers-test.js
+++ b/src/store/__tests__/helpers-test.js
@@ -85,16 +85,22 @@ describe('helpers', () => {
     it('should get all categories', () => {
       const state = fakeState();
 
+      const category1 = fakeCategory({
+        id: 1,
+        ordinal: 2,
+      });
+
+      const category2 = fakeCategory({
+        id: 2,
+        ordinal: 1,
+      });
+
       state.entities.categories = {
-        2: fakeCategory({ id: 2 }),
-        3: fakeCategory({ id: 3 }),
+        1: category1,
+        3: category2,
       };
 
-      expect(getCategories(state))
-      .toEqual([
-        fakeCategory({ id: 2 }),
-        fakeCategory({ id: 3 }),
-      ]);
+      expect(getCategories(state)).toEqual([category2, category1]);
     });
   });
 
@@ -131,11 +137,13 @@ describe('helpers', () => {
       const activity1 = fakeActivity({
         id: 1,
         category: 7,
+        ordinal: 2,
       });
 
       const activity2 = fakeActivity({
         id: 2,
         category: 7,
+        ordinal: 1,
       });
 
       state.entities.activities = {
@@ -147,10 +155,7 @@ describe('helpers', () => {
         }),
       };
 
-      expect(getCategoryActivities(state, 7)).toEqual([
-        activity1,
-        activity2,
-      ]);
+      expect(getCategoryActivities(state, 7)).toEqual([activity2, activity1]);
     });
   });
 

--- a/src/store/helpers.js
+++ b/src/store/helpers.js
@@ -22,16 +22,16 @@ export const getContext = state => {
 };
 
 
-// TODO sort?
-export const getCategories = ({ entities: { categories } }) => values(categories);
+export const getCategories = ({ entities }) =>
+  sortBy(values(entities.categories), 'ordinal');
 
 
-// TODO sort?
-export const getCategoryActivities = ({
-  entities: { activities },
-}, targetCategoryId) => (
-  values(activities)
-    .filter(({ category }) => category === targetCategoryId));
+export const getCategoryActivities = ({ entities }, targetCategoryId) => {
+  const activities = values(entities.activities)
+    .filter(({ category }) => category === targetCategoryId);
+
+  return sortBy(activities, 'ordinal');
+};
 
 
 export const getCategory = ({ entities: { categories } }, id) => categories[id];


### PR DESCRIPTION
At the moment we rely on the ordering in which categories and activities are given by the api. This isn't the same as the ordering in which the items are arranged in wagtail

If no ordinal field is present, we rely on the ordering the api gives us when listing things.