### PR TITLE
Schedule call time disappears when an activity is chosen

### DIFF
--- a/src/actions/__tests__/schedule-test.js
+++ b/src/actions/__tests__/schedule-test.js
@@ -12,6 +12,7 @@ import {
   addScheduledCall,
   addNextScheduledCall,
   openScheduledCall,
+  changeScheduledCallActivity,
   chooseScheduledCallCategory,
   chooseScheduledCallActivity,
   startScheduledCall,
@@ -82,22 +83,40 @@ describe('schedule/actions', () => {
     });
   });
 
+  describe('changeScheduledCallActivity', () => {
+    it('should create an action for choosing a activity', () => {
+      expect(changeScheduledCallActivity({ foo: 23 }))
+        .toEqual({
+          type: constants.SCHEDULED_CALL_ACTIVITY_CHANGE,
+          payload: {
+            context: { foo: 23 },
+          },
+        });
+    });
+  });
+
   describe('chooseScheduledCallCategory', () => {
     it('should create an action for choosing a category', () => {
-      expect(chooseScheduledCallCategory(23))
+      expect(chooseScheduledCallCategory(23, { foo: 21 }))
         .toEqual({
           type: constants.SCHEDULED_CALL_CATEGORY_CHOOSE,
-          payload: { categoryId: 23 },
+          payload: {
+            categoryId: 23,
+            context: { foo: 21 },
+          },
         });
     });
   });
 
   describe('chooseScheduledCallActivity', () => {
-    it('should create an action for choosing a activity', () => {
-      expect(chooseScheduledCallActivity(23))
+    it('should create an action for choosing an activity', () => {
+      expect(chooseScheduledCallActivity(23, { foo: 21 }))
         .toEqual({
           type: constants.SCHEDULED_CALL_ACTIVITY_CHOOSE,
-          payload: { activityId: 23 },
+          payload: {
+            activityId: 23,
+            context: { foo: 21 },
+          },
         });
     });
   });

--- a/src/actions/schedule.js
+++ b/src/actions/schedule.js
@@ -52,23 +52,31 @@ export const openScheduledCall = scheduledCallId => ({
 });
 
 
-export const changeScheduledCallActivity = (
-  staticAction(constants.SCHEDULED_CALL_ACTIVITY_CHANGE));
-
-
 export const removeScheduledCallActivity = (
   staticAction(constants.SCHEDULED_CALL_ACTIVITY_REMOVE));
 
 
-export const chooseScheduledCallCategory = categoryId => ({
-  type: constants.SCHEDULED_CALL_CATEGORY_CHOOSE,
-  payload: { categoryId },
+export const changeScheduledCallActivity = context => ({
+  type: constants.SCHEDULED_CALL_ACTIVITY_CHANGE,
+  payload: { context },
 });
 
 
-export const chooseScheduledCallActivity = activityId => ({
+export const chooseScheduledCallCategory = (categoryId, context) => ({
+  type: constants.SCHEDULED_CALL_CATEGORY_CHOOSE,
+  payload: {
+    categoryId,
+    context,
+  },
+});
+
+
+export const chooseScheduledCallActivity = (activityId, context) => ({
   type: constants.SCHEDULED_CALL_ACTIVITY_CHOOSE,
-  payload: { activityId },
+  payload: {
+    activityId,
+    context,
+  },
 });
 
 

--- a/src/containers/ScheduleDetailContainer.js
+++ b/src/containers/ScheduleDetailContainer.js
@@ -27,14 +27,15 @@ const done = (scheduledCallId, activityId) => ({ callTime }) => {
 
 
 export const mapStateToProps = (state, {
-  scheduledCallId,
+  date,
+  time,
+  callTime,
   activityId,
-  initialDate,
-  initialCallTime,
+  scheduledCallId,
 }) => {
   const {
-    callTime,
-    activity: callActivityId,
+    callTime: scheduledCallTime,
+    activity: scheduledActivityId,
   } = scheduledCallId && getScheduledCall(state, scheduledCallId) || {};
 
   let activity;
@@ -45,8 +46,8 @@ export const mapStateToProps = (state, {
     activity = null;
   } else if (activityId) {
     activity = getActivity(state, activityId);
-  } else if (callActivityId) {
-    activity = getActivity(state, callActivityId);
+  } else if (scheduledActivityId) {
+    activity = getActivity(state, scheduledActivityId);
   }
 
   const calls = reject(getScheduledCalls(state), { id: scheduledCallId });
@@ -54,8 +55,9 @@ export const mapStateToProps = (state, {
   return {
     activity,
     callTimes: map(calls, 'callTime'),
-    initialDate,
-    initialCallTime: callTime || initialCallTime,
+    initialDate: date,
+    initialTime: time,
+    initialCallTime: callTime || scheduledCallTime,
   };
 };
 

--- a/src/containers/ScheduledCallActivityContainer.js
+++ b/src/containers/ScheduledCallActivityContainer.js
@@ -1,3 +1,5 @@
+import { partialRight } from 'lodash';
+import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import ActivityList from 'src/views/ActivityList';
 import { getCategory, getCategoryActivities } from 'src/store/helpers';
@@ -11,10 +13,10 @@ export const mapStateToProps = (state, { categoryId }) => ({
 });
 
 
-export const propToActions = {
-  onActivityPress: chooseScheduledCallActivity,
+export const mapDispatchToProps = (dispatch, { context }) => bindActionCreators({
+  onActivityPress: partialRight(chooseScheduledCallActivity, context),
   onBackPress: dismissScreen,
-};
+}, dispatch);
 
 
-export default connect(mapStateToProps, propToActions)(ActivityList);
+export default connect(mapStateToProps, mapDispatchToProps)(ActivityList);

--- a/src/containers/ScheduledCallCategoryContainer.js
+++ b/src/containers/ScheduledCallCategoryContainer.js
@@ -1,3 +1,5 @@
+import { partialRight } from 'lodash';
+import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import CategoryList from 'src/views/CategoryList';
 import { getCategories } from 'src/store/helpers';
@@ -10,10 +12,10 @@ export const mapStateToProps = state => ({
 });
 
 
-export const propToActions = {
-  onCategoryPress: chooseScheduledCallCategory,
+export const mapDispatchToProps = (dispatch, { context }) => bindActionCreators({
+  onCategoryPress: partialRight(chooseScheduledCallCategory, context),
   onBackPress: dismissScreen,
-};
+}, dispatch);
 
 
-export default connect(mapStateToProps, propToActions)(CategoryList);
+export default connect(mapStateToProps, mapDispatchToProps)(CategoryList);

--- a/src/containers/__tests__/ScheduleDetailContainer-test.js
+++ b/src/containers/__tests__/ScheduleDetailContainer-test.js
@@ -15,7 +15,7 @@ import {
 
 describe('ScheduleDetailContainer', () => {
   describe('mapStateToProps', () => {
-    it('should provide the call time an id is given', () => {
+    it('should provide the call time if an id is given', () => {
       const state = fakeState();
 
       state.entities.scheduledCalls = {
@@ -116,15 +116,24 @@ describe('ScheduleDetailContainer', () => {
     it('should map the given date as the initial date', () => {
       const { initialDate } = mapStateToProps(fakeState(), {
         scheduledCallId: 23,
-        initialDate: '2016-09-22T14:31:23.431Z',
+        date: '2016-09-22T14:31:23.431Z',
       });
 
       expect(initialDate).toEqual('2016-09-22T14:31:23.431Z');
     });
 
+    it('should map the given time as the initial time', () => {
+      const { initialTime } = mapStateToProps(fakeState(), {
+        scheduledCallId: 23,
+        time: '2016-09-22T14:31:23.431Z',
+      });
+
+      expect(initialTime).toEqual('2016-09-22T14:31:23.431Z');
+    });
+
     it('should map the given call time as the initial call time', () => {
       const { initialCallTime } = mapStateToProps(fakeState(), {
-        initialCallTime: '2016-09-22T14:31:23.431Z',
+        callTime: '2016-09-22T14:31:23.431Z',
       });
 
       expect(initialCallTime).toEqual('2016-09-22T14:31:23.431Z');

--- a/src/containers/__tests__/ScheduledCallActivityContainer-test.js
+++ b/src/containers/__tests__/ScheduledCallActivityContainer-test.js
@@ -1,5 +1,10 @@
-import { mapStateToProps } from 'src/containers/ScheduledCallActivityContainer';
 import { fakeState, fakeActivity, fakeCategory } from 'app/scripts/helpers';
+import { chooseScheduledCallActivity } from 'src/actions/schedule';
+import { dismissScreen } from 'src/actions/navigation';
+import {
+  mapStateToProps,
+  mapDispatchToProps,
+} from 'src/containers/ScheduledCallActivityContainer';
 
 
 describe('ScheduledCallActivityContainer', () => {
@@ -46,6 +51,29 @@ describe('ScheduledCallActivityContainer', () => {
       })).toEqual(jasmine.objectContaining({
         activities: [activity1, activity2],
       }));
+    });
+  });
+
+  describe('mapDispatchToProps', () => {
+    it('should map onBackPress to dismissScreen', () => {
+      const dispatch = jest.fn();
+      const { onBackPress } = mapDispatchToProps(dispatch, {});
+      onBackPress();
+      expect(dispatch.mock.calls).toEqual([[dismissScreen()]]);
+    });
+
+    it('should map onActivityPress to chooseScheduledCallActivity', () => {
+      const dispatch = jest.fn();
+
+      const { onActivityPress } = mapDispatchToProps(dispatch, {
+        context: { foo: 21 },
+      });
+
+      onActivityPress(23);
+
+      expect(dispatch.mock.calls).toEqual([[
+        chooseScheduledCallActivity(23, { foo: 21 }),
+      ]]);
     });
   });
 });

--- a/src/containers/__tests__/ScheduledCallCategoryContainer-test.js
+++ b/src/containers/__tests__/ScheduledCallCategoryContainer-test.js
@@ -1,5 +1,10 @@
-import { mapStateToProps } from 'src/containers/ScheduledCallCategoryContainer';
 import { fakeState, fakeCategory } from 'app/scripts/helpers';
+import { chooseScheduledCallCategory } from 'src/actions/schedule';
+import { dismissScreen } from 'src/actions/navigation';
+import {
+  mapStateToProps,
+  mapDispatchToProps,
+} from 'src/containers/ScheduledCallCategoryContainer';
 
 
 describe('ScheduledCallCategoryContainer', () => {
@@ -18,6 +23,29 @@ describe('ScheduledCallCategoryContainer', () => {
           fakeCategory({ id: 23 }),
         ],
       }));
+    });
+  });
+
+  describe('mapDispatchToProps', () => {
+    it('should map onBackPress to dismissScreen', () => {
+      const dispatch = jest.fn();
+      const { onBackPress } = mapDispatchToProps(dispatch, {});
+      onBackPress();
+      expect(dispatch.mock.calls).toEqual([[dismissScreen()]]);
+    });
+
+    it('should map onCategoryPress to chooseScheduledCallCategory', () => {
+      const dispatch = jest.fn();
+
+      const { onCategoryPress } = mapDispatchToProps(dispatch, {
+        context: { foo: 21 },
+      });
+
+      onCategoryPress(23);
+
+      expect(dispatch.mock.calls).toEqual([[
+        chooseScheduledCallCategory(23, { foo: 21 }),
+      ]]);
     });
   });
 });

--- a/src/reducers/navigation/__tests__/schedule-test.js
+++ b/src/reducers/navigation/__tests__/schedule-test.js
@@ -11,16 +11,18 @@ describe('src/reducers/navigation/schedule', () => {
     it('should push on the scheduled call route', () => {
       expect(reduce(createStack(), schedule.addScheduledCall('2016-09-16T11:27:14Z')))
         .toEqual(push(createStack(), createRoute(routes.ROUTE_SCHEDULE_CALL, {
-          initialDate: '2016-09-16T11:27:14Z',
+          date: '2016-09-16T11:27:14Z',
         })));
     });
   });
 
   describe('SCHEDULED_CALL_ADD_NEXT', () => {
     it('should push on the scheduled call route with the next call date', () => {
-      expect(reduce(createStack(), schedule.addNextScheduledCall('2016-09-16T11:27:14Z')))
+      const action = schedule.addNextScheduledCall('2016-09-16T11:27:14Z');
+
+      expect(reduce(createStack(), action))
         .toEqual(push(createStack(), createRoute(routes.ROUTE_SCHEDULE_CALL, {
-          initialCallTime: moment('2016-09-23T11:30:00Z').toISOString(),
+          callTime: moment('2016-09-23T11:30:00Z').toISOString(),
         })));
     });
   });
@@ -36,17 +38,24 @@ describe('src/reducers/navigation/schedule', () => {
 
   describe('SCHEDULED_CALL_ACTIVITY_CHANGE', () => {
     it('should push on the choose category route', () => {
-      expect(reduce(createStack(), schedule.changeScheduledCallActivity()))
-        .toEqual(push(createStack(), createRoute(routes.ROUTE_SCHEDULED_CALL_CATEGORY)));
+      expect(reduce(createStack(), schedule.changeScheduledCallActivity({
+        foo: 21,
+      })))
+      .toEqual(push(createStack(), createRoute(routes.ROUTE_SCHEDULED_CALL_CATEGORY, {
+        context: { foo: 21 },
+      })));
     });
   });
 
   describe('SCHEDULED_CALL_CATEGORY_CHOOSE', () => {
     it('should push on the choose activity route', () => {
-      expect(reduce(createStack(), schedule.chooseScheduledCallCategory(23)))
-        .toEqual(push(createStack(), createRoute(routes.ROUTE_SCHEDULED_CALL_ACTIVITY, {
-          categoryId: 23,
-        })));
+      expect(reduce(createStack(), schedule.chooseScheduledCallCategory(23, {
+        foo: 21,
+      })))
+      .toEqual(push(createStack(), createRoute(routes.ROUTE_SCHEDULED_CALL_ACTIVITY, {
+        categoryId: 23,
+        context: { foo: 21 },
+      })));
     });
   });
 
@@ -58,7 +67,9 @@ describe('src/reducers/navigation/schedule', () => {
         createRoute(routes.ROUTE_SCHEDULED_CALL_ACTIVITY),
       ]);
 
-      const res = reduce(state, schedule.chooseScheduledCallActivity(23));
+      const res = reduce(state, schedule.chooseScheduledCallActivity(23, {
+        foo: 21,
+      }));
 
       expect(res).toEqual({
         index: 0,
@@ -75,11 +86,12 @@ describe('src/reducers/navigation/schedule', () => {
 
       const {
         routes: [{ context }],
-      } = reduce(state, schedule.chooseScheduledCallActivity(23));
+      } = reduce(state, schedule.chooseScheduledCallActivity(23, { foo: 21 }));
 
       expect(context).toEqual({
         scheduledCallId: 21,
         activityId: 23,
+        foo: 21,
       });
     });
   });

--- a/src/reducers/navigation/schedule.js
+++ b/src/reducers/navigation/schedule.js
@@ -16,21 +16,22 @@ export default (state, action) => {
   switch (action.type) {
     case schedule.SCHEDULED_CALL_ADD: {
       const { payload: { date } } = action;
-      const route = createRoute(routes.ROUTE_SCHEDULE_CALL, { initialDate: date });
+      const route = createRoute(routes.ROUTE_SCHEDULE_CALL, { date });
       return push(state, route);
     }
 
     case schedule.SCHEDULED_CALL_ADD_NEXT: {
       const { payload: { date } } = action;
 
-      const initialCallTime = moment(date)
+      const callTime = moment(date)
         .add(1, 'week')
         .round(30, 'minutes')
         .toISOString();
 
       const route = createRoute(routes.ROUTE_SCHEDULE_CALL, {
-        initialCallTime,
+        callTime,
       });
+
       return push(state, route);
     }
 
@@ -41,21 +42,29 @@ export default (state, action) => {
     }
 
     case schedule.SCHEDULED_CALL_ACTIVITY_CHANGE: {
-      const route = createRoute(routes.ROUTE_SCHEDULED_CALL_CATEGORY);
+      const route = createRoute(routes.ROUTE_SCHEDULED_CALL_CATEGORY, action.payload);
       return push(state, route);
     }
 
     case schedule.SCHEDULED_CALL_CATEGORY_CHOOSE: {
-      const { payload: { categoryId } } = action;
-      return push(state, createRoute(routes.ROUTE_SCHEDULED_CALL_ACTIVITY, { categoryId }));
+      const route = createRoute(routes.ROUTE_SCHEDULED_CALL_ACTIVITY, action.payload);
+      return push(state, route);
     }
 
     case schedule.SCHEDULED_CALL_ACTIVITY_CHOOSE: {
-      const { payload: { activityId } } = action;
+      const {
+        payload: {
+          activityId,
+          context,
+        },
+      } = action;
 
       let newState = state;
       newState = pop(pop(newState));
-      newState = inject(newState, routes.ROUTE_SCHEDULE_CALL, { activityId });
+      newState = inject(newState, routes.ROUTE_SCHEDULE_CALL, {
+        ...context,
+        activityId,
+      });
 
       return newState;
     }

--- a/src/views/ScheduleDetail/__tests__/ScheduleDetail-test.js
+++ b/src/views/ScheduleDetail/__tests__/ScheduleDetail-test.js
@@ -69,6 +69,53 @@ describe('ScheduleDetail', () => {
     }));
   });
 
+  it('should use an initial time if given', () => {
+    const el = shallow(createComponent({
+      initialTime: '2016-09-22T14:31:23.431Z',
+    }));
+
+    expect(el.state()).toEqual(jasmine.objectContaining({
+      time: {
+        hour: 16,
+        minute: 31,
+      },
+    }));
+  });
+
+  it('should use an initial date object if given', () => {
+    const el = shallow(createComponent({
+      initialDate: {
+        year: 2016,
+        month: 8,
+        date: 22,
+      },
+    }));
+
+    expect(el.state()).toEqual(jasmine.objectContaining({
+      date: {
+        year: 2016,
+        month: 8,
+        date: 22,
+      },
+    }));
+  });
+
+  it('should use an initial time if given', () => {
+    const el = shallow(createComponent({
+      initialTime: {
+        hour: 16,
+        minute: 31,
+      },
+    }));
+
+    expect(el.state()).toEqual(jasmine.objectContaining({
+      time: {
+        hour: 16,
+        minute: 31,
+      },
+    }));
+  });
+
   it('should use an initial call time as date and time if given', () => {
     const el = shallow(createComponent({
       initialDate: '2016-09-22T14:31:23.431Z',
@@ -199,11 +246,32 @@ describe('ScheduleDetail', () => {
   it('should call onActivityPress when the activity is pressed', () => {
     const onActivityPress = jest.fn();
 
-    shallow(createComponent({ onActivityPress }))
-      .findWhere(uidEquals('activity'))
-      .simulate('press');
+    shallow(createComponent({
+      onActivityPress,
+      initialDate: {
+        year: 2016,
+        month: 8,
+        date: 22,
+      },
+      initialTime: {
+        hour: 16,
+        minute: 31,
+      },
+    }))
+    .findWhere(uidEquals('activity'))
+    .simulate('press');
 
-    expect(onActivityPress.mock.calls).toEqual([[]]);
+    expect(onActivityPress.mock.calls).toEqual([[{
+      date: {
+        year: 2016,
+        month: 8,
+        date: 22,
+      },
+      time: {
+        hour: 16,
+        minute: 31,
+      },
+    }]]);
   });
 
   it('should call onActivityRemovePress when activity remove is pressed', () => {

--- a/src/views/ScheduleDetail/index.js
+++ b/src/views/ScheduleDetail/index.js
@@ -1,4 +1,4 @@
-import { some } from 'lodash';
+import { some, isPlainObject } from 'lodash';
 import moment from 'moment';
 import React, { PropTypes } from 'react';
 import {
@@ -11,6 +11,8 @@ import styles from 'src/views/ScheduleDetail/styles';
 
 
 const dateFromMoment = m => {
+  if (isPlainObject(m)) return m;
+
   const {
     years: year,
     months: month,
@@ -26,6 +28,8 @@ const dateFromMoment = m => {
 
 
 const timeFromMoment = m => {
+  if (isPlainObject(m)) return m;
+
   const {
     hours: hour,
     minutes: minute,
@@ -38,12 +42,16 @@ const timeFromMoment = m => {
 };
 
 
-const parseDateProps = (initialDate, initialCallTime) => {
+const parseDateProps = (initialDate, initialTime, initialCallTime) => {
   let date = null;
   let time = null;
 
   if (initialDate) {
     date = dateFromMoment(initialDate);
+  }
+
+  if (initialTime) {
+    time = timeFromMoment(initialTime);
   }
 
   if (initialCallTime) {
@@ -107,17 +115,19 @@ class ScheduleDetail extends React.Component {
 
     const {
       initialDate = null,
+      initialTime = null,
       initialCallTimeHasChanged = false,
     } = props;
 
     this.state = {
-      ...parseDateProps(initialDate, this.props.initialCallTime),
+      ...parseDateProps(initialDate, initialTime, this.props.initialCallTime),
       timeHasChanged: initialCallTimeHasChanged,
     };
 
     this.onDonePress = this.onDonePress.bind(this);
     this.onDatePress = this.onDatePress.bind(this);
     this.onTimePress = this.onTimePress.bind(this);
+    this.onActivityPress = this.onActivityPress.bind(this);
   }
 
   async onDatePress() {
@@ -162,6 +172,18 @@ class ScheduleDetail extends React.Component {
         ...this.state.time,
       })
       .toISOString(),
+    });
+  }
+
+  onActivityPress() {
+    const {
+      date,
+      time,
+    } = this.state;
+
+    this.props.onActivityPress({
+      date,
+      time,
     });
   }
 
@@ -251,7 +273,7 @@ class ScheduleDetail extends React.Component {
                 removeUid="removeActivity"
                 value={this.props.activity && this.props.activity.title}
                 placeholder="Add Activity (Optional)"
-                onPress={this.props.onActivityPress}
+                onPress={this.onActivityPress}
                 onRemovePress={this.props.onActivityRemovePress}
               />
             </View>
@@ -281,8 +303,9 @@ ScheduleDetail.propTypes = {
   onActivityPress: PropTypes.func.isRequired,
   onActivityRemovePress: PropTypes.func.isRequired,
   onDone: PropTypes.func.isRequired,
-  initialDate: PropTypes.string,
-  initialCallTime: PropTypes.string,
+  initialTime: PropTypes.any,
+  initialDate: PropTypes.any,
+  initialCallTime: PropTypes.any,
   initialCallTimeHasChanged: PropTypes.bool,
   activity: PropTypes.object,
 };


### PR DESCRIPTION
This happens because the view re-renders, but no longer has the relevant time as state. Our options were to change ourn navigation stack to render all views, even if they aren't currently shown, hold onto the current schedule call state in redux while we are busy choosing an activity, or pass along the currently chosen date and time as context while choosing an activity. Option 3 seemed the most sane solution for what we have at the moment.

@codiebeulaine ready for review