### PR TITLE
Fix keyboard disappearing after first character

### DIFF
--- a/src/components/NavigationStack/__tests__/__snapshots__/NavigationStack-test.js.snap
+++ b/src/components/NavigationStack/__tests__/__snapshots__/NavigationStack-test.js.snap
@@ -1,10 +1,1 @@
-exports[`NavigationStack should display a not-found view if the route is not found 1`] = `
-<View>
-  <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail">
-    You have stumbled into an unknown realm of the application. This is certainly a bug, and something that you should never have seen.
-  </Text>
-</View>
-`;
+exports[`NavigationStack should display a not-found view if the route is not found 1`] = `null`;

--- a/src/components/Stepper/__tests__/__snapshots__/Stepper-tests.js.snap
+++ b/src/components/Stepper/__tests__/__snapshots__/Stepper-tests.js.snap
@@ -58,25 +58,52 @@ exports[`Stepper should render its steps 1`] = `
       style={
         Object {
           "flex": 1,
+          "flexDirection": "row",
+          "transform": Array [
+            Object {
+              "translateX": 0,
+            },
+          ],
+          "width": 750,
         }
       }>
       <View
         style={
-          Array [
-            Object {
-              "backgroundColor": "#fff",
-              "flex": 1,
-            },
-            undefined,
-          ]
+          Object {
+            "width": 375,
+          }
         }>
-        <Text
-          accessible={true}
-          allowFontScaling={true}
-          ellipsizeMode="tail">
-          Step 1
-        </Text>
+        <View
+          style={
+            Object {
+              "flex": 1,
+            }
+          }>
+          <View
+            style={
+              Array [
+                Object {
+                  "backgroundColor": "#fff",
+                  "flex": 1,
+                },
+                undefined,
+              ]
+            }>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail">
+              Step 1
+            </Text>
+          </View>
+        </View>
       </View>
+      <View
+        style={
+          Object {
+            "width": 375,
+          }
+        } />
     </View>
   </View>
 </View>
@@ -116,25 +143,52 @@ exports[`Stepper should toggle the rendering of the progressBar 1`] = `
       style={
         Object {
           "flex": 1,
+          "flexDirection": "row",
+          "transform": Array [
+            Object {
+              "translateX": 0,
+            },
+          ],
+          "width": 750,
         }
       }>
       <View
         style={
-          Array [
-            Object {
-              "backgroundColor": "#fff",
-              "flex": 1,
-            },
-            undefined,
-          ]
+          Object {
+            "width": 375,
+          }
         }>
-        <Text
-          accessible={true}
-          allowFontScaling={true}
-          ellipsizeMode="tail">
-          Step 1
-        </Text>
+        <View
+          style={
+            Object {
+              "flex": 1,
+            }
+          }>
+          <View
+            style={
+              Array [
+                Object {
+                  "backgroundColor": "#fff",
+                  "flex": 1,
+                },
+                undefined,
+              ]
+            }>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail">
+              Step 1
+            </Text>
+          </View>
+        </View>
       </View>
+      <View
+        style={
+          Object {
+            "width": 375,
+          }
+        } />
     </View>
   </View>
 </View>


### PR DESCRIPTION
Turns out that this was a [reconciliation](https://facebook.github.io/react/docs/reconciliation.html) issue in `NavigationStack`. When a change happened somewhere, we would re-render the navigation stack. If the active route didn't change, it would render a single route rather than left and right "slides" to transition between. It seems that this change caused the react component to be re-mounted and rendered.

To fix this, we don't change the transition state if the active route has not changed.

@codiebeulaine ready for review