### PR TITLE
Functional device back button

### DIFF
--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -3,7 +3,7 @@ import { normalize, arrayOf } from 'normalizr';
 import { Profile, ScheduledCall, Activity, Category, Event, CallNote } from 'src/api';
 import { getContext } from 'src/store/helpers';
 import { staticAction } from 'src/actionHelpers';
-import { createStack } from 'src/navigationHelpers';
+import { createStack, createRoute } from 'src/navigationHelpers';
 import { EVENT_TYPE_SCHEDULED_CALL_CREATED } from 'src/constants/events';
 import * as api from 'src/api';
 
@@ -145,6 +145,9 @@ export const fakeState = (overrides = {}) => merge({}, {
     callNotes: {
       100: fakeCallNote({ id: 100 }),
     },
+  },
+  navigation: {
+    top: createStack([createRoute('A')]),
   },
 }, overrides);
 

--- a/src/actions/__tests__/navigation-test.js
+++ b/src/actions/__tests__/navigation-test.js
@@ -1,14 +1,61 @@
+jest.mock('BackAndroid');
+
+import { constant, noop } from 'lodash';
+import BackAndroid from 'BackAndroid';
+
 import * as actions from 'src/actions/navigation';
+import * as routes from 'src/constants/routes';
 import * as constants from 'src/constants/navigation';
+import { logout } from 'src/actions/auth';
+import { fakeState, fakeContext } from 'app/scripts/helpers';
+import { createStack, createRoute } from 'src/navigationHelpers';
 
 
 describe('actions/navigation', () => {
+  beforeEach(() => {
+    BackAndroid.exitApp.mockClear();
+  });
+
   describe('changeNavTab', () => {
     it('should create an action for changing the nav tab', () => {
       expect(actions.changeNavTab(constants.NAV_TAB_ACTIVITIES)).toEqual({
         type: constants.NAV_TAB_CHANGE,
         payload: { tab: constants.NAV_TAB_ACTIVITIES },
       });
+    });
+  });
+
+  describe('dismissNative', () => {
+    it('should exit the app if on the landing route', () => {
+      const state = fakeState();
+      const ctx = fakeContext();
+
+      state.navigation.top = createStack([createRoute(routes.ROUTE_LANDING)]);
+      actions.dismissNative()(noop, ctx, constant(state));
+
+      expect(BackAndroid.exitApp.mock.calls).toEqual([[]]);
+    });
+
+    it('should dispatch a logout action if on the navigator route', () => {
+      const state = fakeState();
+      const ctx = fakeContext();
+      const dispatch = jest.fn();
+
+      state.navigation.top = createStack([createRoute(routes.ROUTE_NAVIGATOR)]);
+      actions.dismissNative()(dispatch, ctx, constant(state));
+
+      expect(dispatch.mock.calls).toEqual([[logout()]]);
+    });
+
+    it('should dispatch dismiss screen action otherwise', () => {
+      const state = fakeState();
+      const ctx = fakeContext();
+      const dispatch = jest.fn();
+
+      state.navigation.top = createStack([createRoute('FOO')]);
+      actions.dismissNative()(dispatch, ctx, constant(state));
+
+      expect(dispatch.mock.calls).toEqual([[actions.dismissScreen()]]);
     });
   });
 });

--- a/src/actions/__tests__/navigation-test.js
+++ b/src/actions/__tests__/navigation-test.js
@@ -6,7 +6,6 @@ import BackAndroid from 'BackAndroid';
 import * as actions from 'src/actions/navigation';
 import * as routes from 'src/constants/routes';
 import * as constants from 'src/constants/navigation';
-import { logout } from 'src/actions/auth';
 import { fakeState, fakeContext } from 'app/scripts/helpers';
 import { createStack, createRoute } from 'src/navigationHelpers';
 
@@ -36,15 +35,14 @@ describe('actions/navigation', () => {
       expect(BackAndroid.exitApp.mock.calls).toEqual([[]]);
     });
 
-    it('should dispatch a logout action if on the navigator route', () => {
+    it('should exit the app if on the navigator route', () => {
       const state = fakeState();
       const ctx = fakeContext();
-      const dispatch = jest.fn();
 
       state.navigation.top = createStack([createRoute(routes.ROUTE_NAVIGATOR)]);
-      actions.dismissNative()(dispatch, ctx, constant(state));
+      actions.dismissNative()(noop, ctx, constant(state));
 
-      expect(dispatch.mock.calls).toEqual([[logout()]]);
+      expect(BackAndroid.exitApp.mock.calls).toEqual([[]]);
     });
 
     it('should dispatch dismiss screen action otherwise', () => {

--- a/src/actions/navigation.js
+++ b/src/actions/navigation.js
@@ -1,5 +1,10 @@
 import { staticAction } from 'src/actionHelpers';
 import * as constants from 'src/constants/navigation';
+import BackAndroid from 'BackAndroid';
+
+import * as routes from 'src/constants/routes';
+import { getActiveTopRoute } from 'src/store/helpers';
+import { logout } from 'src/actions/auth';
 
 
 export const dismissScreen = staticAction(constants.SCREEN_DISMISS);
@@ -9,3 +14,20 @@ export const changeNavTab = tab => ({
   type: constants.NAV_TAB_CHANGE,
   payload: { tab },
 });
+
+
+export const dismissNative = () => (dispatch, ctx, getState) => {
+  const state = getState();
+  const activeRoute = getActiveTopRoute(state);
+
+  switch (activeRoute.key) {
+    case routes.ROUTE_LANDING:
+      return BackAndroid.exitApp();
+
+    case routes.ROUTE_NAVIGATOR:
+      return dispatch(logout());
+
+    default:
+      return dispatch(dismissScreen());
+  }
+};

--- a/src/actions/navigation.js
+++ b/src/actions/navigation.js
@@ -4,7 +4,6 @@ import BackAndroid from 'BackAndroid';
 
 import * as routes from 'src/constants/routes';
 import { getActiveTopRoute } from 'src/store/helpers';
-import { logout } from 'src/actions/auth';
 
 
 export const dismissScreen = staticAction(constants.SCREEN_DISMISS);
@@ -22,10 +21,8 @@ export const dismissNative = () => (dispatch, ctx, getState) => {
 
   switch (activeRoute.key) {
     case routes.ROUTE_LANDING:
-      return BackAndroid.exitApp();
-
     case routes.ROUTE_NAVIGATOR:
-      return dispatch(logout());
+      return BackAndroid.exitApp();
 
     default:
       return dispatch(dismissScreen());

--- a/src/app.js
+++ b/src/app.js
@@ -1,9 +1,11 @@
 import 'moment-round';
 import React from 'react';
 import { Provider } from 'react-redux';
+import BackAndroid from 'BackAndroid';
 
 import errors from 'src/errors';
 import tick from 'src/actions/tick';
+import { dismissNative } from 'src/actions/navigation';
 import configureStore from 'src/store/configureStore';
 import TopNavigationContainer from 'src/containers/TopNavigationContainer';
 
@@ -11,6 +13,12 @@ import TopNavigationContainer from 'src/containers/TopNavigationContainer';
 const store = configureStore();
 errors(store);
 store.dispatch(tick());
+
+
+BackAndroid.addEventListener('hardwareBackPress', () => {
+  store.dispatch(dismissNative());
+  return true;
+});
 
 
 const App = function App() {

--- a/src/components/Overlay/Loading/__tests__/__snapshots__/Loading-test.js.snap
+++ b/src/components/Overlay/Loading/__tests__/__snapshots__/Loading-test.js.snap
@@ -148,7 +148,7 @@ ShallowWrapper {
   "renderer": ReactShallowRenderer {
     "_instance": ShallowComponentWrapper {
       "_calledComponentWillUnmount": false,
-      "_compositeType": 2,
+      "_compositeType": 0,
       "_context": Object {},
       "_currentElement": <LoadingOverlay
         onDismissPress={[Function]}
@@ -156,9 +156,10 @@ ShallowWrapper {
       "_debugID": 1,
       "_hostContainerInfo": null,
       "_hostParent": null,
-      "_instance": StatelessComponent {
+      "_instance": LoadingOverlay {
         "_reactInternalInstance": [Circular],
         "context": Object {},
+        "onNativeBackPress": [Function],
         "props": Object {
           "onDismissPress": [Function],
           "title": "Waiting for the 7:18…",

--- a/src/components/Overlay/Loading/index.js
+++ b/src/components/Overlay/Loading/index.js
@@ -1,31 +1,55 @@
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { View } from 'react-native';
+import BackAndroid from 'BackAndroid';
 
 import { BaseView, SpinningImage, Header, HeaderIcon, Text } from 'src/components';
 import styles from 'src/components/Overlay/Loading/styles';
 
 
-const LoadingOverlay = ({
-  title,
-  onDismissPress,
-}) => (
-  <BaseView style={styles.base}>
-    <Header style={styles.header}>
-      {
-        onDismissPress && <HeaderIcon
-          uid="dismiss"
-          type={HeaderIcon.types.dismissLight}
-          onPress={onDismissPress}
-        />
-      }
-    </Header>
+class LoadingOverlay extends Component {
+  constructor(props) {
+    super(props);
+    this.onNativeBackPress = this.onNativeBackPress.bind(this);
+  }
 
-    <View style={styles.body}>
-      <SpinningImage />
-      <Text style={styles.title}>{title}</Text>
-    </View>
-  </BaseView>
-);
+  componentDidMount() {
+    BackAndroid.addEventListener('hardwareBackPress', this.onNativeBackPress);
+  }
+
+  componentWillUnmount() {
+    BackAndroid.removeEventListener('hardwareBackPress', this.onNativeBackPress);
+  }
+
+  onNativeBackPress() {
+    return true;
+  }
+
+  render() {
+    const {
+      title,
+      onDismissPress,
+    } = this.props;
+
+    return (
+      <BaseView style={styles.base}>
+        <Header style={styles.header}>
+          {
+            onDismissPress && <HeaderIcon
+              uid="dismiss"
+              type={HeaderIcon.types.dismissLight}
+              onPress={onDismissPress}
+            />
+          }
+        </Header>
+
+        <View style={styles.body}>
+          <SpinningImage />
+          <Text style={styles.title}>{title}</Text>
+        </View>
+      </BaseView>
+    );
+  }
+}
 
 
 LoadingOverlay.propTypes = {

--- a/src/components/Stepper/__tests__/Stepper-tests.js
+++ b/src/components/Stepper/__tests__/Stepper-tests.js
@@ -64,4 +64,33 @@ describe('Stepper', () => {
 
     expect(el.state().index).toEqual(1);
   });
+
+  describe('onNativeBackPress', () => {
+    it('should go back', () => {
+      const el = shallow(createComponent());
+
+      el.setState({ index: 1 })
+        .instance()
+        .onNativeBackPress();
+
+      expect(el.state().index).toEqual(0);
+    });
+
+    it('should return false when at step 0', () => {
+      let res;
+      const el = shallow(createComponent());
+
+      res = el.setState({ index: 1 })
+        .instance()
+        .onNativeBackPress();
+
+      expect(res).toBe(true);
+
+      res = el.setState({ index: 0 })
+        .instance()
+        .onNativeBackPress();
+
+      expect(res).toBe(false);
+    });
+  });
 });

--- a/src/components/Stepper/index.js
+++ b/src/components/Stepper/index.js
@@ -1,5 +1,7 @@
 import { range, clamp, fromPairs, debounce } from 'lodash';
 import React, { Component, PropTypes } from 'react';
+import BackAndroid from 'BackAndroid';
+
 import { ProgressBar, BaseView, FormView, NavigationStack } from 'src/components';
 import { createRoute } from 'src/navigationHelpers';
 
@@ -32,6 +34,24 @@ class Stepper extends Component {
 
     this.onNextPress = debouncePager(this.onNextPress.bind(this));
     this.onBackPress = debouncePager(this.onBackPress.bind(this));
+    this.onNativeBackPress = this.onNativeBackPress.bind(this);
+  }
+
+  componentDidMount() {
+    BackAndroid.addEventListener('hardwareBackPress', this.onNativeBackPress);
+  }
+
+  componentWillUnmount() {
+    BackAndroid.removeEventListener('hardwareBackPress', this.onNativeBackPress);
+  }
+
+  onNativeBackPress() {
+    if (this.state.index > 0) {
+      this.onBackPress();
+      return true;
+    } else {
+      return false;
+    }
   }
 
   onNextPress() {

--- a/src/store/__tests__/helpers-test.js
+++ b/src/store/__tests__/helpers-test.js
@@ -6,6 +6,11 @@ import {
 } from 'src/constants/events';
 
 import {
+  createStack,
+  createRoute,
+} from 'src/navigationHelpers';
+
+import {
   fakeState,
   fakeProfile,
   fakeAuth,
@@ -33,6 +38,7 @@ import {
   getCallNote,
   getNextScheduledCall,
   getScheduledCallsBetween,
+  getActiveTopRoute,
 } from 'src/store/helpers';
 
 
@@ -418,6 +424,17 @@ describe('helpers', () => {
       };
 
       expect(getCallNote(state, 2)).toEqual(callNote1);
+    });
+  });
+
+  describe('getActiveTopRoute', () => {
+    it('should get the active top route', () => {
+      const state = fakeState();
+      const route1 = createRoute('1');
+      const route2 = createRoute('2');
+      state.navigation.top = createStack([route1, route2]);
+
+      expect(getActiveTopRoute(state)).toEqual(route2);
     });
   });
 });

--- a/src/store/helpers.js
+++ b/src/store/helpers.js
@@ -1,6 +1,7 @@
 import moment from 'moment';
 import { values, isUndefined, sortBy, filter, first } from 'lodash';
 
+import { getCurrent } from 'src/navigationHelpers';
 import { TYPES_TO_COLLECTIONS } from 'src/constants/events';
 
 
@@ -102,3 +103,6 @@ const getEventObject = (state, event) => {
 // TODO return the associated entitites to make the containers' jobs easier
 export const getEvents = state => values(state.entities.events)
   .filter(event => getEventObject(state, event));
+
+
+export const getActiveTopRoute = store => getCurrent(store.navigation.top);


### PR DESCRIPTION
This PR adds the following behaviour when device back button is pressed:
  - if on landing screen, exit app
  - else if on a 'main' page (not overlays are showing), logout
  - else if not in a stepper, dismiss the current overlay
  - else if in a stepper (onboarding, call notes)
    - if not at step 0, go back a step
    - else revert to steps above

@codiebeulaine ready for review