### PR TITLE
Parsing for rich text api fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "react-native-image-picker": "^0.24.1",
     "react-redux": "^4.4.5",
     "redux": "^3.4.0",
-    "redux-thunk": "^2.0.1"
+    "redux-thunk": "^2.0.1",
+    "simple-markdown": "^0.2.1"
   },
   "devDependencies": {
     "babel-cli": "^6.7.5",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-native-config": "^0.1.0",
     "react-native-fcm": "^2.0.3",
     "react-native-image-picker": "^0.24.1",
+    "react-native-simple-markdown": "^1.0.60-rc.3",
     "react-redux": "^4.4.5",
     "redux": "^3.4.0",
     "redux-thunk": "^2.0.1",

--- a/src/api/__tests__/richText-test.js
+++ b/src/api/__tests__/richText-test.js
@@ -1,6 +1,6 @@
 jest.mock('simple-markdown');
 
-import { richText } from 'src/api';
+import { richText, imageUrl } from 'src/api';
 import { defaultBlockParse } from 'simple-markdown';
 
 
@@ -172,6 +172,20 @@ describe('api/richText', () => {
         type: 'text',
         content: 'bar',
       }],
+    }]);
+  });
+
+  it('should support images', () => {
+    const fn = richText({
+      image: richText.image,
+    });
+
+    expect(fn([{
+      type: 'image',
+      value: '/foo.png',
+    }]).tree).toEqual([{
+      type: 'mentorshipImage',
+      url: imageUrl('/foo.png'),
     }]);
   });
 });

--- a/src/api/__tests__/richText-test.js
+++ b/src/api/__tests__/richText-test.js
@@ -1,0 +1,56 @@
+import { richText } from 'src/api';
+
+
+describe('api/richText', () => {
+  it('should serialize to its original form', () => {
+    const fn = richText({
+      list: richText.list(),
+    });
+
+    const input = [{
+      type: 'list',
+      value: [
+        'foo',
+        'bar',
+      ],
+    }];
+
+    expect(fn(input).toJSON()).toEqual(input);
+  });
+
+  it('should throw error for unrecognised types', () => {
+    const fn = richText({
+      list: richText.list(),
+    });
+
+    expect(() => fn([{
+      type: 'foo',
+      value: 'bar',
+    }])).toThrow("Unrecognised rich text type 'foo'");
+  });
+
+  it('should support unordered lists', () => {
+    const fn = richText({
+      list: richText.list(),
+    });
+
+    expect(fn([{
+      type: 'list',
+      value: [
+        'foo',
+        'bar',
+      ],
+    }]).tree).toEqual([{
+      type: 'list',
+      start: void 0,
+      ordered: false,
+      items: [{
+        type: 'text',
+        content: 'foo',
+      }, {
+        type: 'text',
+        content: 'bar',
+      }],
+    }]);
+  });
+});

--- a/src/api/__tests__/richText-test.js
+++ b/src/api/__tests__/richText-test.js
@@ -1,7 +1,14 @@
+jest.mock('simple-markdown');
+
 import { richText } from 'src/api';
+import { defaultBlockParse } from 'simple-markdown';
 
 
 describe('api/richText', () => {
+  afterEach(() => {
+    defaultBlockParse.mockClear();
+  });
+
   it('should serialize to its original form', () => {
     const fn = richText({
       list: richText.list,
@@ -40,6 +47,25 @@ describe('api/richText', () => {
     }]).tree).toEqual([{
       type: 'text',
       content: 'foo',
+    }]);
+  });
+
+  it('should support markdown', () => {
+    defaultBlockParse.mockImplementation(content => ({
+      type: 'fake-markdown',
+      content,
+    }));
+
+    const fn = richText({
+      text: richText.markdown,
+    });
+
+    expect(fn([{
+      type: 'text',
+      value: '*foo*',
+    }]).tree).toEqual([{
+      type: 'fake-markdown',
+      content: '*foo*',
     }]);
   });
 

--- a/src/api/__tests__/richText-test.js
+++ b/src/api/__tests__/richText-test.js
@@ -4,7 +4,7 @@ import { richText } from 'src/api';
 describe('api/richText', () => {
   it('should serialize to its original form', () => {
     const fn = richText({
-      list: richText.list(),
+      list: richText.list,
     });
 
     const input = [{
@@ -20,7 +20,7 @@ describe('api/richText', () => {
 
   it('should throw error for unrecognised types', () => {
     const fn = richText({
-      list: richText.list(),
+      list: richText.list,
     });
 
     expect(() => fn([{
@@ -29,9 +29,23 @@ describe('api/richText', () => {
     }])).toThrow("Unrecognised rich text type 'foo'");
   });
 
+  it('should support text', () => {
+    const fn = richText({
+      text: richText.text,
+    });
+
+    expect(fn([{
+      type: 'text',
+      value: 'foo',
+    }]).tree).toEqual([{
+      type: 'text',
+      content: 'foo',
+    }]);
+  });
+
   it('should support unordered lists', () => {
     const fn = richText({
-      list: richText.list(),
+      list: richText.list,
     });
 
     expect(fn([{
@@ -44,6 +58,31 @@ describe('api/richText', () => {
       type: 'list',
       start: void 0,
       ordered: false,
+      items: [{
+        type: 'text',
+        content: 'foo',
+      }, {
+        type: 'text',
+        content: 'bar',
+      }],
+    }]);
+  });
+
+  it('should support numbered lists', () => {
+    const fn = richText({
+      numberedList: richText.numberedList,
+    });
+
+    expect(fn([{
+      type: 'numberedList',
+      value: [
+        'foo',
+        'bar',
+      ],
+    }]).tree).toEqual([{
+      type: 'list',
+      start: 1,
+      ordered: true,
       items: [{
         type: 'text',
         content: 'foo',

--- a/src/api/__tests__/richText-test.js
+++ b/src/api/__tests__/richText-test.js
@@ -50,6 +50,62 @@ describe('api/richText', () => {
     }]);
   });
 
+  it('support arbitrary heading levels', () => {
+    const fn = richText({
+      heading: richText.heading(23),
+    });
+
+    expect(fn([{
+      type: 'heading',
+      value: 'foo',
+    }]).tree).toEqual([{
+      type: 'heading',
+      level: 23,
+      content: [{
+        type: 'text',
+        content: 'foo',
+      }],
+    }]);
+  });
+
+  it('support heading levels 1-6', () => {
+    const fn = richText({
+      h1: richText.heading1,
+      h2: richText.heading2,
+      h3: richText.heading3,
+      h4: richText.heading4,
+      h5: richText.heading5,
+      h6: richText.heading6,
+    });
+
+    expect(fn([{
+      type: 'h1',
+      value: 'foo',
+    }, {
+      type: 'h2',
+      value: 'bar',
+    }, {
+      type: 'h3',
+      value: 'baz',
+    }, {
+      type: 'h4',
+      value: 'quux',
+    }, {
+      type: 'h5',
+      value: 'corge',
+    }, {
+      type: 'h6',
+      value: 'grault',
+    }]).tree).toEqual([
+      richText.heading(1)('foo'),
+      richText.heading(2)('bar'),
+      richText.heading(3)('baz'),
+      richText.heading(4)('quux'),
+      richText.heading(5)('corge'),
+      richText.heading(6)('grault'),
+    ]);
+  });
+
   it('should support markdown', () => {
     defaultBlockParse.mockImplementation(content => ({
       type: 'fake-markdown',

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -10,5 +10,7 @@ export * from 'src/api/calls';
 export * from 'src/api/notificationSettings';
 export * from 'src/api/callNotes';
 export * from 'src/api/messages';
+export * from 'src/api/richText';
 export * from 'src/api/imageUrl';
+export { default as richText } from 'src/api/richText';
 export { default as imageUrl } from 'src/api/imageUrl';

--- a/src/api/richText.js
+++ b/src/api/richText.js
@@ -1,0 +1,38 @@
+const parseItem = ({ type, value }, types) => {
+  if (!(type in types)) throw new Error(`Unrecognised rich text type '${type}'`);
+  return types[type](value);
+};
+
+
+export const parse = (data, types) => data
+  .map(d => parseItem(d, types));
+
+
+export class RichText {
+  constructor(input, tree) {
+    this.input = input;
+    this.tree = tree;
+  }
+
+  toJSON() {
+    return this.input;
+  }
+}
+
+
+const richText = types => input => new RichText(input, parse(input, types));
+
+
+richText.list = (conf = {}) => value => ({
+  ordered: false,
+  start: void 0,
+  type: 'list',
+  items: value.map(content => ({
+    type: 'text',
+    content,
+  })),
+  ...conf,
+});
+
+
+export default richText;

--- a/src/api/richText.js
+++ b/src/api/richText.js
@@ -1,3 +1,4 @@
+import { assign, range, fromPairs } from 'lodash';
 import { defaultBlockParse } from 'simple-markdown';
 
 
@@ -35,6 +36,13 @@ richText.text = content => ({
 });
 
 
+richText.heading = level => content => ({
+  type: 'heading',
+  level,
+  content: [richText.text(content)],
+});
+
+
 richText.list = items => ({
   ordered: false,
   start: void 0,
@@ -48,6 +56,12 @@ richText.numberedList = items => ({
   start: 1,
   ordered: true,
 });
+
+
+assign(richText, fromPairs(range(1, 7).map(n => [
+  `heading${n}`,
+  richText.heading(n),
+])));
 
 
 export default richText;

--- a/src/api/richText.js
+++ b/src/api/richText.js
@@ -35,4 +35,11 @@ richText.list = (conf = {}) => value => ({
 });
 
 
+richText.numberedList = (conf = {}) => richText.list({
+  start: 1,
+  ordered: true,
+  ...conf,
+});
+
+
 export default richText;

--- a/src/api/richText.js
+++ b/src/api/richText.js
@@ -1,5 +1,6 @@
 import { assign, range, fromPairs } from 'lodash';
 import { defaultBlockParse } from 'simple-markdown';
+import imageUrl from 'src/api/imageUrl';
 
 
 const parseItem = ({ type, value }, types) => {
@@ -55,6 +56,12 @@ richText.numberedList = items => ({
   ...richText.list(items),
   start: 1,
   ordered: true,
+});
+
+
+richText.image = url => ({
+  type: 'mentorshipImage',
+  url: imageUrl(url),
 });
 
 

--- a/src/api/richText.js
+++ b/src/api/richText.js
@@ -1,3 +1,6 @@
+import { defaultBlockParse } from 'simple-markdown';
+
+
 const parseItem = ({ type, value }, types) => {
   if (!(type in types)) throw new Error(`Unrecognised rich text type '${type}'`);
   return types[type](value);
@@ -21,6 +24,9 @@ export class RichText {
 
 
 const richText = types => input => new RichText(input, parse(input, types));
+
+
+richText.markdown = content => defaultBlockParse(content);
 
 
 richText.text = content => ({

--- a/src/api/richText.js
+++ b/src/api/richText.js
@@ -23,22 +23,24 @@ export class RichText {
 const richText = types => input => new RichText(input, parse(input, types));
 
 
-richText.list = (conf = {}) => value => ({
-  ordered: false,
-  start: void 0,
-  type: 'list',
-  items: value.map(content => ({
-    type: 'text',
-    content,
-  })),
-  ...conf,
+richText.text = content => ({
+  type: 'text',
+  content,
 });
 
 
-richText.numberedList = (conf = {}) => richText.list({
+richText.list = items => ({
+  ordered: false,
+  start: void 0,
+  type: 'list',
+  items: items.map(richText.text),
+});
+
+
+richText.numberedList = items => ({
+  ...richText.list(items),
   start: 1,
   ordered: true,
-  ...conf,
 });
 
 


### PR DESCRIPTION
To avoid duplicating code and doing more work than we need to, the plan is to draw components using [simple-markdown](https://github.com/Khan/simple-markdown) with the react-native-specific rules defined by [react-native-simple-markdown](https://github.com/CharlesMangwa/react-native-simple-markdown) (for both markdown-based rich text fields, and non-markdown based rich text fields defined directly in wagtail). This means that most of the time, we should only need to override styles, and the actual implementation of the rich text types is done for us already by react-native-simple-markdown. It also means we don't need different implementations for markdown-based rich text fields and non-markdown-based rich text fields.

First step for that ^ approach is to add parsing support for all rich text field types we get from wagtail, to allow us to parse these fields into a syntax tree recognised by [simple-markdown](https://github.com/Khan/simple-markdown).

@miltontony ready for review