### PR TITLE
Basics for RichText component

### DIFF
--- a/src/components/RichText/__tests__/RichText-test.js
+++ b/src/components/RichText/__tests__/RichText-test.js
@@ -67,4 +67,29 @@ describe('RichText', () => {
       <RichText rules={rules}>{richText()('rule overrides')}</RichText>
     )).toMatchSnapshot();
   });
+
+  describe('shouldComponentUpdate', () => {
+    it('should compare props via a SameValueZero comparison', () => {
+      const content1 = richText()('foo');
+      const content2 = richText()('foo');
+
+      const props = {
+        styles: {},
+        rules: () => ({}),
+        children: content1,
+      };
+
+      const el = shallow(<RichText {...props} />);
+
+      expect(el.instance().shouldComponentUpdate({
+        ...props,
+        children: content1,
+      })).toEqual(false);
+
+      expect(el.instance().shouldComponentUpdate({
+        ...props,
+        children: content2,
+      })).toEqual(true);
+    });
+  });
 });

--- a/src/components/RichText/__tests__/RichText-test.js
+++ b/src/components/RichText/__tests__/RichText-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RichText } from 'src/components';
+import { Text, RichText } from 'src/components';
 import { richText } from 'src/api';
 
 
@@ -23,6 +23,7 @@ describe('RichText', () => {
         ###### h6
 
         text
+
         [link](http://www.google.com)
 
         *italics*
@@ -42,12 +43,28 @@ describe('RichText', () => {
   });
 
   it('should support style overrides', () => {
+    const styles = {
+      text: { fontSize: 100 },
+    };
+
     expect(render(
-      <RichText
-        styles={{
-          text: { fontSize: 100 },
-        }}
-      >{richText()(`style overrides`)}</RichText>
+      <RichText styles={styles}>{richText()('style overrides')}</RichText>
+    )).toMatchSnapshot();
+  });
+
+  it('should support rule overrides', () => {
+    const rules = styles => ({
+      text: {
+        react: (node, _, state) => (
+          <Text key={state.key} style={[styles.text, { color: '#cc3333' }]}>
+            {node.content}
+          </Text>
+        ),
+      },
+    });
+
+    expect(render(
+      <RichText rules={rules}>{richText()('rule overrides')}</RichText>
     )).toMatchSnapshot();
   });
 });

--- a/src/components/RichText/__tests__/RichText-test.js
+++ b/src/components/RichText/__tests__/RichText-test.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { RichText } from 'src/components';
+
+
+describe('RichText', () => {
+  it('should render text');
+});

--- a/src/components/RichText/__tests__/RichText-test.js
+++ b/src/components/RichText/__tests__/RichText-test.js
@@ -1,7 +1,43 @@
 import React from 'react';
 import { RichText } from 'src/components';
+import { richText } from 'src/api';
 
 
 describe('RichText', () => {
-  it('should render text');
+  it('should render typography', () => {
+    // TODO get underlining working
+    // TODO get inline code working
+    // TODO get code blocks working
+    expect(render(
+      <RichText>{richText()(`
+        # h1
+
+        ## h2
+
+        ### h3
+
+        #### h4
+
+        ##### h5
+
+        ###### h6
+
+        text
+        [link](http://www.google.com)
+
+        *italics*
+        **bold**
+        ***bold italics***
+        ~~strikeout~~
+
+        > block quote
+
+        - unordered
+        - list
+
+        1. numbered
+        2. list
+      `)}</RichText>
+    )).toMatchSnapshot();
+  });
 });

--- a/src/components/RichText/__tests__/RichText-test.js
+++ b/src/components/RichText/__tests__/RichText-test.js
@@ -40,4 +40,14 @@ describe('RichText', () => {
       `)}</RichText>
     )).toMatchSnapshot();
   });
+
+  it('should support style overrides', () => {
+    expect(render(
+      <RichText
+        styles={{
+          text: { fontSize: 100 },
+        }}
+      >{richText()(`style overrides`)}</RichText>
+    )).toMatchSnapshot();
+  });
 });

--- a/src/components/RichText/__tests__/__snapshots__/RichText-test.js.snap
+++ b/src/components/RichText/__tests__/__snapshots__/RichText-test.js.snap
@@ -214,22 +214,26 @@ exports[`RichText should support rule overrides 1`] = `
       style={
         Array [
           Object {
-            "color": "#003035",
-            "fontFamily": "Brandon Text",
-            "fontSize": 13,
-            "textAlign": "center",
+            "color": "#222222",
           },
-          Array [
-            Object {
-              "color": "#222222",
-            },
-            Object {
-              "color": "#cc3333",
-            },
-          ],
+          undefined,
         ]
       }>
-      rule overrides
+      rule 
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "#222222",
+          },
+          undefined,
+        ]
+      }>
+      overrides
     </Text>
   </Text>
 </View>

--- a/src/components/RichText/__tests__/__snapshots__/RichText-test.js.snap
+++ b/src/components/RichText/__tests__/__snapshots__/RichText-test.js.snap
@@ -189,3 +189,97 @@ exports[`RichText should render typography 1`] = `
     } />
 </View>
 `;
+
+exports[`RichText should support rule overrides 1`] = `
+<View
+  style={Object {}}>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Object {
+        "alignItems": "flex-start",
+        "flexDirection": "row",
+        "flexWrap": "wrap",
+        "justifyContent": "flex-start",
+        "marginBottom": 10,
+        "marginTop": 10,
+      }
+    }>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "#003035",
+            "fontFamily": "Brandon Text",
+            "fontSize": 13,
+            "textAlign": "center",
+          },
+          Array [
+            Object {
+              "color": "#222222",
+            },
+            Object {
+              "color": "#cc3333",
+            },
+          ],
+        ]
+      }>
+      rule overrides
+    </Text>
+  </Text>
+</View>
+`;
+
+exports[`RichText should support style overrides 1`] = `
+<View
+  style={Object {}}>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Object {
+        "alignItems": "flex-start",
+        "flexDirection": "row",
+        "flexWrap": "wrap",
+        "justifyContent": "flex-start",
+        "marginBottom": 10,
+        "marginTop": 10,
+      }
+    }>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "fontSize": 100,
+          },
+          undefined,
+        ]
+      }>
+      style 
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "fontSize": 100,
+          },
+          undefined,
+        ]
+      }>
+      overrides
+    </Text>
+  </Text>
+</View>
+`;

--- a/src/components/RichText/__tests__/__snapshots__/RichText-test.js.snap
+++ b/src/components/RichText/__tests__/__snapshots__/RichText-test.js.snap
@@ -214,26 +214,22 @@ exports[`RichText should support rule overrides 1`] = `
       style={
         Array [
           Object {
-            "color": "#222222",
+            "color": "#003035",
+            "fontFamily": "Brandon Text",
+            "fontSize": 13,
+            "textAlign": "center",
           },
-          undefined,
+          Array [
+            Object {
+              "color": "#222222",
+            },
+            Object {
+              "color": "#cc3333",
+            },
+          ],
         ]
       }>
-      rule 
-    </Text>
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-      style={
-        Array [
-          Object {
-            "color": "#222222",
-          },
-          undefined,
-        ]
-      }>
-      overrides
+      rule overrides
     </Text>
   </Text>
 </View>

--- a/src/components/RichText/__tests__/__snapshots__/RichText-test.js.snap
+++ b/src/components/RichText/__tests__/__snapshots__/RichText-test.js.snap
@@ -1,0 +1,191 @@
+exports[`RichText should render typography 1`] = `
+<View
+  style={Object {}}>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={undefined}>
+    
+    
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "fontWeight": "200",
+        },
+        Object {
+          "fontSize": 32,
+        },
+      ]
+    }>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "#222222",
+          },
+        ]
+      }>
+      h1
+    </Text>
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "fontWeight": "200",
+        },
+        Object {
+          "fontSize": 24,
+        },
+      ]
+    }>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "#222222",
+          },
+        ]
+      }>
+      h2
+    </Text>
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "fontWeight": "200",
+        },
+        Object {
+          "fontSize": 18,
+        },
+      ]
+    }>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "#222222",
+          },
+        ]
+      }>
+      h3
+    </Text>
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "fontWeight": "200",
+        },
+        Object {
+          "fontSize": 16,
+        },
+      ]
+    }>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "#222222",
+          },
+        ]
+      }>
+      h4
+    </Text>
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "fontWeight": "200",
+        },
+        Object {
+          "fontSize": 13,
+        },
+      ]
+    }>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "#222222",
+          },
+        ]
+      }>
+      h5
+    </Text>
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "fontWeight": "200",
+        },
+        Object {
+          "fontSize": 11,
+        },
+      ]
+    }>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "#222222",
+          },
+        ]
+      }>
+      h6
+    </Text>
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Object {
+        "fontFamily": "Courier",
+        "fontWeight": "500",
+      }
+    } />
+</View>
+`;

--- a/src/components/RichText/index.js
+++ b/src/components/RichText/index.js
@@ -1,4 +1,4 @@
-import { merge } from 'lodash/fp';
+import { mergeAll } from 'lodash/fp';
 import { some, eq } from 'lodash';
 import React, { Component, PropTypes } from 'react';
 import { View } from 'react-native';
@@ -30,12 +30,12 @@ class RichText extends Component {
   }
 
   getRules(styles) {
-    return merge(
+    return mergeAll([
       SimpleMarkdown.defaultRules,
       mdRules(styles),
       baseRules(styles),
       this.props.rules(styles),
-    );
+    ]);
   }
 
   getRenderFn(styles) {

--- a/src/components/RichText/index.js
+++ b/src/components/RichText/index.js
@@ -11,6 +11,10 @@ import baseStyles from './styles';
 
 
 class RichText extends Component {
+  static defaultProps = {
+    styles: {},
+  };
+
   shouldComponentUpdate() {
   }
 
@@ -18,6 +22,7 @@ class RichText extends Component {
     return {
       ...mdStyles,
       ...baseStyles,
+      ...this.props.styles,
     };
   }
 
@@ -49,6 +54,7 @@ class RichText extends Component {
 
 RichText.propTypes = {
   children: PropTypes.instanceOf(RichTextObject).isRequired,
+  styles: PropTypes.any,
 };
 
 

--- a/src/components/RichText/index.js
+++ b/src/components/RichText/index.js
@@ -1,8 +1,12 @@
+import { merge } from 'lodash';
 import React, { Component, PropTypes } from 'react';
 import { View } from 'react-native';
+import SimpleMarkdown from 'simple-markdown';
 import mdStyles from 'react-native-simple-markdown/styles';
+import mdRules from 'react-native-simple-markdown/rules';
 
 import { RichText as RichTextObject } from 'src/api';
+import baseRules from './rules';
 import baseStyles from './styles';
 
 
@@ -17,11 +21,27 @@ class RichText extends Component {
     };
   }
 
+  getRules(styles) {
+    return merge(
+      SimpleMarkdown.defaultRules,
+      mdRules(styles),
+      baseRules(styles));
+  }
+
+  getRenderFn(styles) {
+    const rules = this.getRules(styles);
+    return SimpleMarkdown.reactFor(SimpleMarkdown.ruleOutput(rules, 'react'));
+  }
+
   render() {
     const styles = this.getStyles();
+    const renderFn = this.getRenderFn(styles);
+    const { children } = this.props;
 
     return (
-      <View style={styles.container} />
+      <View style={styles.container}>
+        {renderFn(children.tree)}
+      </View>
     );
   }
 }

--- a/src/components/RichText/index.js
+++ b/src/components/RichText/index.js
@@ -13,6 +13,7 @@ import baseStyles from './styles';
 class RichText extends Component {
   static defaultProps = {
     styles: {},
+    rules: () => ({}),
   };
 
   shouldComponentUpdate() {
@@ -30,7 +31,9 @@ class RichText extends Component {
     return merge(
       SimpleMarkdown.defaultRules,
       mdRules(styles),
-      baseRules(styles));
+      baseRules(styles),
+      this.props.rules(styles),
+    );
   }
 
   getRenderFn(styles) {
@@ -55,6 +58,7 @@ class RichText extends Component {
 RichText.propTypes = {
   children: PropTypes.instanceOf(RichTextObject).isRequired,
   styles: PropTypes.any,
+  rules: PropTypes.func,
 };
 
 

--- a/src/components/RichText/index.js
+++ b/src/components/RichText/index.js
@@ -1,4 +1,5 @@
-import { merge } from 'lodash';
+import { merge } from 'lodash/fp';
+import { some, eq } from 'lodash';
 import React, { Component, PropTypes } from 'react';
 import { View } from 'react-native';
 import SimpleMarkdown from 'simple-markdown';
@@ -16,7 +17,8 @@ class RichText extends Component {
     rules: () => ({}),
   };
 
-  shouldComponentUpdate() {
+  shouldComponentUpdate(nextProps) {
+    return some(this.props, (v, k) => !eq(nextProps[k], v));
   }
 
   getStyles() {

--- a/src/components/RichText/index.js
+++ b/src/components/RichText/index.js
@@ -1,0 +1,35 @@
+import React, { Component, PropTypes } from 'react';
+import { View } from 'react-native';
+import mdStyles from 'react-native-simple-markdown/styles';
+
+import { RichText as RichTextObject } from 'src/api';
+import baseStyles from './styles';
+
+
+class RichText extends Component {
+  shouldComponentUpdate() {
+  }
+
+  getStyles() {
+    return {
+      ...mdStyles,
+      ...baseStyles,
+    };
+  }
+
+  render() {
+    const styles = this.getStyles();
+
+    return (
+      <View style={styles.container} />
+    );
+  }
+}
+
+
+RichText.propTypes = {
+  children: PropTypes.instanceOf(RichTextObject).isRequired,
+};
+
+
+export default RichText;

--- a/src/components/RichText/rules.js
+++ b/src/components/RichText/rules.js
@@ -1,0 +1,5 @@
+const rules = () => ({
+});
+
+
+export default rules;

--- a/src/components/RichText/styles.js
+++ b/src/components/RichText/styles.js
@@ -1,0 +1,7 @@
+import { StyleSheet } from 'react-native';
+
+
+export default StyleSheet.create({
+  container: {
+  },
+});

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -28,6 +28,7 @@ import RadioList from './RadioList';
 import PatternBackground from './PatternBackground';
 import FormStep from './FormStep';
 import NavigationStack from './NavigationStack';
+import RichText from './RichText';
 
 
 export {
@@ -62,4 +63,5 @@ export {
   PatternBackground,
   FormStep,
   NavigationStack,
+  RichText,
 };


### PR DESCRIPTION
This adds a `RichText` component that uses the syntax trees returned by `richText()` (adding in #312) as input.

See #312's description for some context on the approach taken for `RichText`'s implementation.

Styling to come in separate PRs.