### PR TITLE
Fixes for non-markdown rich text fields

### DIFF
--- a/src/api/__tests__/richText-test.js
+++ b/src/api/__tests__/richText-test.js
@@ -98,6 +98,23 @@ describe('api/richText', () => {
     }]);
   });
 
+  it('should support paragraphs', () => {
+    const fn = richText({
+      paragraph: richText.paragraph,
+    });
+
+    expect(fn({
+      type: 'paragraph',
+      value: 'foo',
+    }).tree).toEqual([{
+      type: 'paragraph',
+      content: [{
+        type: 'text',
+        content: 'foo',
+      }],
+    }]);
+  });
+
   it('support arbitrary heading levels', () => {
     const fn = richText({
       heading: richText.heading(23),

--- a/src/api/__tests__/richText-test.js
+++ b/src/api/__tests__/richText-test.js
@@ -205,13 +205,13 @@ describe('api/richText', () => {
       type: 'list',
       start: void 0,
       ordered: false,
-      items: [{
+      items: [[{
         type: 'text',
         content: 'foo',
-      }, {
+      }], [{
         type: 'text',
         content: 'bar',
-      }],
+      }]],
     }]);
   });
 
@@ -230,13 +230,13 @@ describe('api/richText', () => {
       type: 'list',
       start: 1,
       ordered: true,
-      items: [{
+      items: [[{
         type: 'text',
         content: 'foo',
-      }, {
+      }], [{
         type: 'text',
         content: 'bar',
-      }],
+      }]],
     }]);
   });
 

--- a/src/api/richText.js
+++ b/src/api/richText.js
@@ -12,6 +12,12 @@ const text = content => ({
 });
 
 
+const paragraph = content => ({
+  type: 'paragraph',
+  content: [text(content)],
+});
+
+
 const heading = level => content => ({
   type: 'heading',
   level,
@@ -58,8 +64,9 @@ const parseItem = (d, mappings) => {
 
 
 const types = {
-  markdown,
   text,
+  markdown,
+  paragraph,
   heading,
   list,
   numberedList,

--- a/src/api/richText.js
+++ b/src/api/richText.js
@@ -37,7 +37,7 @@ const list = items => ({
   ordered: false,
   start: void 0,
   type: 'list',
-  items: items.map(text),
+  items: items.map(item => [text(item)]),
 });
 
 

--- a/src/components/RichText/styles.js
+++ b/src/components/RichText/styles.js
@@ -15,6 +15,10 @@ export default {
   },
   del: {
   },
+  blockQuoteSection: {
+    ...mdStyles.blockQuoteSection,
+    marginBottom: 20,
+  },
   blockQuoteSectionBar: {
     ...mdStyles.blockQuoteSectionBar,
     backgroundColor: colors.BG_DARK,
@@ -25,8 +29,12 @@ export default {
   }],
   u: {
   },
+  list: {
+    marginBottom: 20,
+  },
   listItemText: {
     ...omit(mdStyles.listItemText, 'color'),
+    flex: 1,
     fontSize: FONT_SIZE_NORMAL,
   },
   listItemNumber: {


### PR DESCRIPTION
Now that we are able to draw these fields, there were a few minor differences between the syntax trees we create via our rich text components, and the ones created via simple-markdown.

@Mitso @nathanbegbie depends on #316, otherwise ready for review