### PR TITLE
Fetch recent events on call note create success

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -7,6 +7,7 @@ import { load } from 'src/actions/sync';
 import { sequence } from 'src/actionHelpers';
 import { setupNotifications } from 'src/actions/notifications';
 import { EVENT_POLL_TICK } from 'src/constants/events';
+import { CALL_NOTE_CREATE_SUCCESS } from 'src/constants/callNotes';
 
 import { SCHEDULED_CALL_CREATE_SUCCESS } from 'src/constants/schedule';
 import { listRecentEvents, startEventPolling } from 'src/actions/events';
@@ -16,6 +17,7 @@ export default fromPairs([
   [AUTH_LOGIN_SUCCESS, sequence([enter, setupNotifications, startEventPolling])],
   [EXISTING_USER_ENTER, load],
   [ONBOARDING_SETUP_PROFILE_SUCCESS, load],
-  [SCHEDULED_CALL_CREATE_SUCCESS, listRecentEvents],
   [EVENT_POLL_TICK, listRecentEvents],
+  [CALL_NOTE_CREATE_SUCCESS, listRecentEvents],
+  [SCHEDULED_CALL_CREATE_SUCCESS, listRecentEvents],
 ]);


### PR DESCRIPTION
At the moment we poll for new events to update the journey screen, and fetch recent events creating a new thing via the api if we know that an event would be created as a side effect. Call notes is one of those things, except we still need to set things up to fetch recent events when call notes are created.

@Mitso @nathanbegbie ready for review