### PR TITLE
Support code in rich text

### DIFF
--- a/src/components/RichText/__tests__/RichText-test.js
+++ b/src/components/RichText/__tests__/RichText-test.js
@@ -5,7 +5,6 @@ import { richText } from 'src/api';
 
 describe('RichText', () => {
   it('should render typography', () => {
-    // TODO get code blocks working
     expect(render(
       <RichText>{richText()(`
 # h1

--- a/src/components/RichText/__tests__/RichText-test.js
+++ b/src/components/RichText/__tests__/RichText-test.js
@@ -36,6 +36,10 @@ __***underline bold italics***__
 
 > block quote
 
+\`\`\`
+code block
+\`\`\`
+
 - unordered
 - list
 

--- a/src/components/RichText/__tests__/RichText-test.js
+++ b/src/components/RichText/__tests__/RichText-test.js
@@ -5,7 +5,6 @@ import { richText } from 'src/api';
 
 describe('RichText', () => {
   it('should render typography', () => {
-    // TODO get inline code working
     // TODO get code blocks working
     expect(render(
       <RichText>{richText()(`
@@ -33,6 +32,7 @@ __underline__
 __*underline italics*__
 __**underline bold**__
 __***underline bold italics***__
+\`inlineCode\`
 
 > block quote
 

--- a/src/components/RichText/__tests__/__snapshots__/RichText-test.js.snap
+++ b/src/components/RichText/__tests__/__snapshots__/RichText-test.js.snap
@@ -740,14 +740,9 @@ exports[`RichText should render typography 1`] = `
       style={
         Object {
           "backgroundColor": "#dfe5e6",
-          "borderColor": "#dddddd",
-          "borderRadius": 3,
-          "borderWidth": 1,
           "color": "#80979a",
           "fontFamily": "Courier",
           "fontSize": 14,
-          "fontWeight": "bold",
-          "padding": 18,
         }
       }>
       inlineCode
@@ -825,6 +820,29 @@ exports[`RichText should render typography 1`] = `
           quote
         </Text>
       </Text>
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "backgroundColor": "#dfe5e6",
+        "marginBottom": 20,
+        "padding": 6,
+      }
+    }>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Object {
+          "backgroundColor": "#dfe5e6",
+          "color": "#80979a",
+          "fontFamily": "Courier",
+          "fontSize": 14,
+        }
+      }>
+      code block
     </Text>
   </View>
   <View

--- a/src/components/RichText/__tests__/__snapshots__/RichText-test.js.snap
+++ b/src/components/RichText/__tests__/__snapshots__/RichText-test.js.snap
@@ -718,6 +718,40 @@ exports[`RichText should render typography 1`] = `
         </Text>
       </Text>
     </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "#003035",
+            "fontFamily": "Brandon Text",
+          },
+        ]
+      }>
+      
+      
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Object {
+          "backgroundColor": "#dfe5e6",
+          "borderColor": "#dddddd",
+          "borderRadius": 3,
+          "borderWidth": 1,
+          "color": "#80979a",
+          "fontFamily": "Courier",
+          "fontSize": 14,
+          "fontWeight": "bold",
+          "padding": 18,
+        }
+      }>
+      inlineCode
+    </Text>
   </Text>
   <View
     style={

--- a/src/components/RichText/rules.js
+++ b/src/components/RichText/rules.js
@@ -1,6 +1,6 @@
 import { isString } from 'lodash';
 import React from 'react';
-import { Text } from 'react-native';
+import { View, Text } from 'react-native';
 
 import Image from './Image';
 
@@ -30,6 +30,15 @@ const rules = styles => ({
   },
   inlineCode: {
     react: reactTextType(styles.inlineCode),
+  },
+  codeBlock: {
+    react: (node, output, state) => (
+      <View key={state.key} style={styles.codeBlock}>
+        <Text style={styles.codeBlockContent}>
+          {node.content}
+        </Text>
+      </View>
+    ),
   },
 });
 

--- a/src/components/RichText/rules.js
+++ b/src/components/RichText/rules.js
@@ -1,7 +1,22 @@
+import { isString } from 'lodash';
 import React from 'react';
 import { Text } from 'react-native';
 
 import Image from './Image';
+
+
+const reactTextType = style => (node, output, state) => {
+  const children = isString(node.content)
+    ? node.content
+    : output(node.content, {
+      ...state,
+      withinText: true,
+    });
+
+  return (
+    <Text key={state.key} style={style}>{children}</Text>
+  );
+};
 
 
 const rules = styles => ({
@@ -11,16 +26,10 @@ const rules = styles => ({
     ),
   },
   u: {
-    react: (node, output, state) => {
-      const children = output(node.content, {
-        ...state,
-        withinText: true,
-      });
-
-      return (
-        <Text key={state.key} style={styles.u}>{children}</Text>
-      );
-    },
+    react: reactTextType(styles.u),
+  },
+  inlineCode: {
+    react: reactTextType(styles.inlineCode),
   },
 });
 

--- a/src/components/RichText/styles.js
+++ b/src/components/RichText/styles.js
@@ -9,6 +9,13 @@ import Text from 'src/components/Text';
 
 const FONT_SIZE_NORMAL = 18;
 
+const code = {
+  fontFamily: 'Courier',
+  color: colors.RICH_TEXT_CODE_TEXT,
+  backgroundColor: colors.RICH_TEXT_CODE_BG,
+  fontSize: FONT_SIZE_NORMAL - 4,
+};
+
 
 export default {
   container: {
@@ -35,19 +42,7 @@ export default {
     fontSize: FONT_SIZE_NORMAL - 3,
   },
   inlineCode: {
-    ...mdStyles.inlineCode,
-    color: colors.RICH_TEXT_CODE_TEXT,
-    backgroundColor: colors.RICH_TEXT_CODE_BG,
-    fontSize: FONT_SIZE_NORMAL - 4,
-    padding: 18,
-  },
-  blockQuoteSection: {
-    ...mdStyles.blockQuoteSection,
-    marginBottom: 20,
-  },
-  blockQuoteSectionBar: {
-    ...mdStyles.blockQuoteSectionBar,
-    backgroundColor: colors.BG_DARK,
+    ...code,
   },
   text: Text.styles.default,
   paragraph: [Text.types.paragraph, {
@@ -105,6 +100,22 @@ export default {
     fontSize: 13,
     marginTop: 6,
     marginBottom: 3,
+  },
+  blockQuoteSection: {
+    ...mdStyles.blockQuoteSection,
+    marginBottom: 20,
+  },
+  blockQuoteSectionBar: {
+    ...mdStyles.blockQuoteSectionBar,
+    backgroundColor: colors.BG_DARK,
+  },
+  codeBlock: {
+    backgroundColor: colors.RICH_TEXT_CODE_BG,
+    padding: 6,
+    marginBottom: 20,
+  },
+  codeBlockContent: {
+    ...code,
   },
   table: {
   },

--- a/src/components/RichText/styles.js
+++ b/src/components/RichText/styles.js
@@ -34,6 +34,13 @@ export default {
     ...mdStyles.em,
     fontSize: FONT_SIZE_NORMAL - 3,
   },
+  inlineCode: {
+    ...mdStyles.inlineCode,
+    color: colors.RICH_TEXT_CODE_TEXT,
+    backgroundColor: colors.RICH_TEXT_CODE_BG,
+    fontSize: FONT_SIZE_NORMAL - 4,
+    padding: 18,
+  },
   blockQuoteSection: {
     ...mdStyles.blockQuoteSection,
     marginBottom: 20,

--- a/src/constants/colors.js
+++ b/src/constants/colors.js
@@ -127,4 +127,7 @@ export default {
   MESSAGE_BUBBLE_BG_PENDING: '#c0cbcc',
   MESSAGE_BUBBLE_TIME_TEXT: 'rgba(0, 0, 0, 0.30)',
   MESSAGE_BUBBLE_HINT_TEXT: 'rgba(0, 0, 0, 0.30)',
+
+  RICH_TEXT_CODE_TEXT: '#80979a',
+  RICH_TEXT_CODE_BG: '#dfe5e6',
 };


### PR DESCRIPTION
Very unlikely this will be used, but at the moment it just breaks. We should at least show something, rather than have the app break.

Inline code obviously needs some padding, but [this isn't possible](https://github.com/facebook/react-native/issues/3233) for react native `Text` yet, and we don't have the luxury of being able to wrap code in a `View` for this case, since the tree for inline code ends up being nested inside a `Text` element (`View` elements cannot be nested inside `Text`s, at least not yet).