### PR TITLE
Navigation stack throws away old routes' view state

### DIFF
--- a/src/components/NavigationStack/__tests__/NavigationStack-test.js
+++ b/src/components/NavigationStack/__tests__/NavigationStack-test.js
@@ -7,7 +7,6 @@ import NavigationStack from 'src/components/NavigationStack';
 import { createStack, createRoute, push, pop } from 'src/navigationHelpers';
 import { Text } from 'src/components';
 import { DEVICE_WIDTH } from 'src/constants/styles';
-import { uidEquals } from 'app/scripts/helpers';
 
 
 describe('NavigationStack', () => {

--- a/src/components/NavigationStack/__tests__/NavigationStack-test.js
+++ b/src/components/NavigationStack/__tests__/NavigationStack-test.js
@@ -7,6 +7,7 @@ import NavigationStack from 'src/components/NavigationStack';
 import { createStack, createRoute, push, pop } from 'src/navigationHelpers';
 import { Text } from 'src/components';
 import { DEVICE_WIDTH } from 'src/constants/styles';
+import { uidEquals } from 'app/scripts/helpers';
 
 
 describe('NavigationStack', () => {
@@ -64,13 +65,7 @@ describe('NavigationStack', () => {
 
     const { position } = el.state();
 
-    expect(el.find('A').length).toEqual(0);
-    expect(el.find('B').length).toEqual(1);
-
     el.setProps({ navigationState: pop(navigationState) });
-
-    expect(el.find('A').length).toEqual(1);
-    expect(el.find('B').length).toEqual(1);
 
     expect(position.value).toEqual(1);
 
@@ -96,15 +91,9 @@ describe('NavigationStack', () => {
     const el = shallow(createComponent({ navigationState }));
     const { position } = el.state();
 
-    expect(el.find('A').length).toEqual(1);
-    expect(el.find('B').length).toEqual(0);
-
     el.setProps({
       navigationState: push(navigationState, createRoute('B')),
     });
-
-    expect(el.find('A').length).toEqual(1);
-    expect(el.find('B').length).toEqual(1);
 
     expect(position.value).toEqual(0);
 
@@ -136,18 +125,12 @@ describe('NavigationStack', () => {
     const el = shallow(createComponent({ navigationState }));
     const { position } = el.state();
 
-    expect(el.find('A').length).toEqual(1);
-    expect(el.find('B').length).toEqual(0);
-
     el.setProps({
       navigationState: {
         ...navigationState,
         index: 1,
       },
     });
-
-    expect(el.find('A').length).toEqual(1);
-    expect(el.find('B').length).toEqual(1);
 
     expect(position.value).toEqual(0);
 
@@ -168,17 +151,28 @@ describe('NavigationStack', () => {
     expect(start.mock.calls).toEqual([[]]);
   });
 
-  it('should only render the current route if the stack has not changed', () => {
+  it('should only update stack state if active route has changed', () => {
     const navigationState = createStack([createRoute('A')]);
-    const el = shallow(createComponent({ navigationState }));
 
-    expect(el.find('A').length).toEqual(1);
-    expect(el.find('B').length).toEqual(0);
+    const nextNavigationState = createStack([
+      createRoute('A'),
+      createRoute('B'),
+    ]);
+
+    const el = shallow(createComponent({ navigationState }));
+    const prevState = el.state();
 
     el.setProps({ navigationState });
+    expect(el.state()).toEqual(prevState);
 
-    expect(el.find('A').length).toEqual(1);
-    expect(el.find('B').length).toEqual(0);
+    el.setProps({ navigationState: nextNavigationState });
+
+    expect(el.state()).not.toEqual(prevState);
+
+    expect(el.state()).toEqual(jasmine.objectContaining({
+      prev: prevState.curr,
+      curr: nextNavigationState,
+    }));
   });
 
   it('should support react elements as routes', () => {

--- a/src/components/NavigationStack/index.js
+++ b/src/components/NavigationStack/index.js
@@ -174,7 +174,8 @@ class NavigationStack extends Component {
       <View
         key={route.key}
         uid={route.key}
-        style={[styles.slide, isHidden && styles.slideIsHidden]}>
+        style={[styles.slide, isHidden && styles.slideIsHidden]}
+      >
         {this.renderRoute(route)}
       </View>
     );

--- a/src/components/NavigationStack/index.js
+++ b/src/components/NavigationStack/index.js
@@ -162,7 +162,7 @@ class NavigationStack extends Component {
     const obj = this.props.routes[key];
 
     if (React.isValidElement(obj)) {
-      return <View style={styles.routeContainer}>{obj}</View>;
+      return <View style={styles.route}>{obj}</View>;
     } else {
       const Route = obj || NotFound;
       return <Route {...context} />;

--- a/src/components/NavigationStack/index.js
+++ b/src/components/NavigationStack/index.js
@@ -1,3 +1,4 @@
+import { includes } from 'lodash';
 import React, { Component, PropTypes } from 'react';
 import { View, StyleSheet, Animated } from 'react-native';
 
@@ -12,10 +13,13 @@ const styles = StyleSheet.create({
     width: DEVICE_WIDTH * 2,
     flexDirection: 'row',
   },
-  slideContainer: {
+  slide: {
     width: DEVICE_WIDTH,
   },
-  routeContainer: {
+  slideIsHidden: {
+    width: 0,
+  },
+  route: {
     flex: 1,
   },
 });
@@ -96,6 +100,57 @@ class NavigationStack extends Component {
     });
   }
 
+  getShownRoutes() {
+    const {
+      curr,
+      prev,
+    } = this.state;
+
+    let res;
+
+    switch (getDirection(prev, curr)) {
+      case DIRECTION_LEFTWARD:
+        res = [curr, prev];
+        break;
+
+      case DIRECTION_RIGHTWARD:
+        res = [prev, curr];
+        break;
+
+      default:
+        res = [curr];
+        break;
+    }
+
+    return res.map(getCurrent);
+  }
+
+  getRoutesExcluding(excludes) {
+    const keys = excludes.map(({ key }) => key);
+    return this.state.curr.routes
+      .filter(route => !includes(keys, route.key));
+  }
+
+  getSlides() {
+    const shownRoutes = this.getShownRoutes();
+
+    const hidden = this.getRoutesExcluding(shownRoutes)
+      .map(route => ({
+        route,
+        isHidden: true,
+      }));
+
+    const shown = shownRoutes
+      .map(route => ({
+        route,
+        isHidden: false,
+      }));
+
+    return []
+      .concat(hidden)
+      .concat(shown);
+  }
+
   animate(to) {
     Animated.timing(this.state.position, {
       duration: DURATION,
@@ -114,36 +169,23 @@ class NavigationStack extends Component {
     }
   }
 
-  renderSlides(leftStack, rightStack = null) {
+  renderSlide({ route, isHidden }) {
     return (
-      <Animated.View style={[styles.container, animatedStyles(this.state.position)]}>
-        <View key="left" style={styles.slideContainer}>
-          {this.renderRoute(getCurrent(leftStack))}
-        </View>
-
-        <View key="right" style={styles.slideContainer}>
-          {rightStack && this.renderRoute(getCurrent(rightStack))}
-        </View>
-      </Animated.View>
+      <View
+        key={route.key}
+        uid={route.key}
+        style={[styles.slide, isHidden && styles.slideIsHidden]}>
+        {this.renderRoute(route)}
+      </View>
     );
   }
 
   render() {
-    const {
-      curr,
-      prev,
-    } = this.state;
-
-    switch (getDirection(prev, curr)) {
-      case DIRECTION_LEFTWARD:
-        return this.renderSlides(curr, prev);
-
-      case DIRECTION_RIGHTWARD:
-        return this.renderSlides(prev, curr);
-
-      default:
-        return this.renderSlides(curr);
-    }
+    return (
+      <Animated.View style={[styles.container, animatedStyles(this.state.position)]}>
+        {this.getSlides().map(this.renderSlide, this)}
+      </Animated.View>
+    );
   }
 }
 

--- a/src/components/Stepper/__tests__/__snapshots__/Stepper-tests.js.snap
+++ b/src/components/Stepper/__tests__/__snapshots__/Stepper-tests.js.snap
@@ -69,10 +69,51 @@ exports[`Stepper should render its steps 1`] = `
       }>
       <View
         style={
-          Object {
-            "width": 375,
-          }
-        }>
+          Array [
+            Object {
+              "width": 375,
+            },
+            Object {
+              "width": 0,
+            },
+          ]
+        }
+        uid={1}>
+        <View
+          style={
+            Object {
+              "flex": 1,
+            }
+          }>
+          <View
+            style={
+              Array [
+                Object {
+                  "backgroundColor": "#fff",
+                  "flex": 1,
+                },
+                undefined,
+              ]
+            }>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail">
+              Step 2
+            </Text>
+          </View>
+        </View>
+      </View>
+      <View
+        style={
+          Array [
+            Object {
+              "width": 375,
+            },
+            false,
+          ]
+        }
+        uid={0}>
         <View
           style={
             Object {
@@ -98,12 +139,6 @@ exports[`Stepper should render its steps 1`] = `
           </View>
         </View>
       </View>
-      <View
-        style={
-          Object {
-            "width": 375,
-          }
-        } />
     </View>
   </View>
 </View>
@@ -154,10 +189,51 @@ exports[`Stepper should toggle the rendering of the progressBar 1`] = `
       }>
       <View
         style={
-          Object {
-            "width": 375,
-          }
-        }>
+          Array [
+            Object {
+              "width": 375,
+            },
+            Object {
+              "width": 0,
+            },
+          ]
+        }
+        uid={1}>
+        <View
+          style={
+            Object {
+              "flex": 1,
+            }
+          }>
+          <View
+            style={
+              Array [
+                Object {
+                  "backgroundColor": "#fff",
+                  "flex": 1,
+                },
+                undefined,
+              ]
+            }>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail">
+              Step 2
+            </Text>
+          </View>
+        </View>
+      </View>
+      <View
+        style={
+          Array [
+            Object {
+              "width": 375,
+            },
+            false,
+          ]
+        }
+        uid={0}>
         <View
           style={
             Object {
@@ -183,12 +259,6 @@ exports[`Stepper should toggle the rendering of the progressBar 1`] = `
           </View>
         </View>
       </View>
-      <View
-        style={
-          Object {
-            "width": 375,
-          }
-        } />
     </View>
   </View>
 </View>


### PR DESCRIPTION
At the moment, `NavigationStack` (the component responsible for transitioning between routes) only renders the view if it is being transitioned to or from. This means that we lose view state for all other routes on the stack that are not being shown.

To fix this, we should still render the hidden views, except not actually display them.

@Mitso @nathanbegbie ready for review