### PR TITLE
"Three words" onboarding screen allows empty strings as words

### DIFF
--- a/src/views/Onboarding/ThreeWords/__tests__/ThreeWords-test.js
+++ b/src/views/Onboarding/ThreeWords/__tests__/ThreeWords-test.js
@@ -31,6 +31,9 @@ describe('ThreeWords', () => {
     expect(paginationDisabled('foo bar')).toBe(true);
     expect(paginationDisabled('foo, bar')).toBe(true);
     expect(paginationDisabled('foo bar baz quux')).toBe(true);
+    expect(paginationDisabled('foo,,,')).toBe(true);
+    expect(paginationDisabled('foo,bar,')).toBe(true);
+    expect(paginationDisabled('foo,bar,,')).toBe(true);
     expect(paginationDisabled('foo bar baz')).toBe(false);
     expect(paginationDisabled('foo,bar  baz')).toBe(false);
   });

--- a/src/views/Onboarding/ThreeWords/index.js
+++ b/src/views/Onboarding/ThreeWords/index.js
@@ -1,3 +1,4 @@
+import { compact } from 'lodash';
 import React, { PropTypes } from 'react';
 
 import { Text, TextInput, FormStep } from 'src/components';
@@ -7,7 +8,7 @@ import styles from 'src/views/Onboarding/styles';
 const DELIM = /[\s,]+/;
 
 
-const getTags = s => s.split(DELIM);
+const getTags = s => compact(s.split(DELIM));
 
 
 const ThreeWords = ({


### PR DESCRIPTION
For e.g. `foo,bar,` would count as words `['foo', 'bar', '']`, when it should be `['foo', 'bar']`.

@Mitso @nathanbegbie ready for review