### PR TITLE
Fix text wrapping for call note detail view

### DIFF
--- a/src/components/Section/__tests__/__snapshots__/Section-test.js.snap
+++ b/src/components/Section/__tests__/__snapshots__/Section-test.js.snap
@@ -10,6 +10,7 @@ exports[`Section should render 1`] = `
       Object {
         "borderBottomColor": "#dfe5e6",
         "borderBottomWidth": 1,
+        "marginBottom": 12,
         "paddingBottom": 11,
       }
     }>
@@ -52,8 +53,7 @@ exports[`Section should render 1`] = `
         },
         Object {
           "fontSize": 18,
-          "paddingBottom": 12,
-          "paddingTop": 18,
+          "marginBottom": 12,
           "textAlign": "left",
         },
       ]

--- a/src/components/Section/styles.js
+++ b/src/components/Section/styles.js
@@ -9,6 +9,7 @@ export default StyleSheet.create({
   },
   header: {
     paddingBottom: 11,
+    marginBottom: 12,
     borderBottomWidth: 1,
     borderBottomColor: colors.SECTION_DIVIDER,
   },

--- a/src/components/Text/__tests__/__snapshots__/Test-test.js.snap
+++ b/src/components/Text/__tests__/__snapshots__/Test-test.js.snap
@@ -33,8 +33,7 @@ exports[`Text should render paragraphs 1`] = `
       },
       Object {
         "fontSize": 18,
-        "paddingBottom": 12,
-        "paddingTop": 18,
+        "marginBottom": 12,
         "textAlign": "left",
       },
     ]

--- a/src/components/Text/styles.js
+++ b/src/components/Text/styles.js
@@ -31,8 +31,7 @@ export const types = StyleSheet.create({
   paragraph: {
     textAlign: 'left',
     fontSize: 18,
-    paddingTop: 18,
-    paddingBottom: 12,
+    marginBottom: 12,
   },
 
   sectionTitle: {

--- a/src/views/Activity/__tests__/__snapshots__/Activity-test.js.snap
+++ b/src/views/Activity/__tests__/__snapshots__/Activity-test.js.snap
@@ -188,7 +188,7 @@ exports[`Activity should display the poster if one is given 1`] = `
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -198,6 +198,7 @@ exports[`Activity should display the poster if one is given 1`] = `
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -261,8 +262,7 @@ exports[`Activity should display the poster if one is given 1`] = `
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -274,7 +274,7 @@ exports[`Activity should display the poster if one is given 1`] = `
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -284,6 +284,7 @@ exports[`Activity should display the poster if one is given 1`] = `
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -347,8 +348,7 @@ exports[`Activity should display the poster if one is given 1`] = `
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -360,7 +360,7 @@ exports[`Activity should display the poster if one is given 1`] = `
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -370,6 +370,7 @@ exports[`Activity should display the poster if one is given 1`] = `
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -433,8 +434,7 @@ exports[`Activity should display the poster if one is given 1`] = `
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -446,7 +446,7 @@ exports[`Activity should display the poster if one is given 1`] = `
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -456,6 +456,7 @@ exports[`Activity should display the poster if one is given 1`] = `
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -519,8 +520,7 @@ exports[`Activity should display the poster if one is given 1`] = `
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -532,7 +532,7 @@ exports[`Activity should display the poster if one is given 1`] = `
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -542,6 +542,7 @@ exports[`Activity should display the poster if one is given 1`] = `
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -605,8 +606,7 @@ exports[`Activity should display the poster if one is given 1`] = `
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -618,7 +618,7 @@ exports[`Activity should display the poster if one is given 1`] = `
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -628,6 +628,7 @@ exports[`Activity should display the poster if one is given 1`] = `
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -691,8 +692,7 @@ exports[`Activity should display the poster if one is given 1`] = `
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -965,7 +965,7 @@ exports[`Activity should display the relevant context for the latest call note 1
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -975,6 +975,7 @@ exports[`Activity should display the relevant context for the latest call note 1
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -1038,8 +1039,7 @@ exports[`Activity should display the relevant context for the latest call note 1
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -1051,7 +1051,7 @@ exports[`Activity should display the relevant context for the latest call note 1
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -1061,6 +1061,7 @@ exports[`Activity should display the relevant context for the latest call note 1
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -1124,8 +1125,7 @@ exports[`Activity should display the relevant context for the latest call note 1
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -1137,7 +1137,7 @@ exports[`Activity should display the relevant context for the latest call note 1
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -1147,6 +1147,7 @@ exports[`Activity should display the relevant context for the latest call note 1
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -1210,8 +1211,7 @@ exports[`Activity should display the relevant context for the latest call note 1
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -1223,7 +1223,7 @@ exports[`Activity should display the relevant context for the latest call note 1
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -1233,6 +1233,7 @@ exports[`Activity should display the relevant context for the latest call note 1
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -1296,8 +1297,7 @@ exports[`Activity should display the relevant context for the latest call note 1
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -1309,7 +1309,7 @@ exports[`Activity should display the relevant context for the latest call note 1
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -1319,6 +1319,7 @@ exports[`Activity should display the relevant context for the latest call note 1
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -1382,8 +1383,7 @@ exports[`Activity should display the relevant context for the latest call note 1
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -1395,7 +1395,7 @@ exports[`Activity should display the relevant context for the latest call note 1
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -1405,6 +1405,7 @@ exports[`Activity should display the relevant context for the latest call note 1
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -1468,8 +1469,7 @@ exports[`Activity should display the relevant context for the latest call note 1
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -1743,7 +1743,7 @@ exports[`Activity should display the relevant context for the next scheduled cal
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -1753,6 +1753,7 @@ exports[`Activity should display the relevant context for the next scheduled cal
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -1816,8 +1817,7 @@ exports[`Activity should display the relevant context for the next scheduled cal
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -1829,7 +1829,7 @@ exports[`Activity should display the relevant context for the next scheduled cal
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -1839,6 +1839,7 @@ exports[`Activity should display the relevant context for the next scheduled cal
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -1902,8 +1903,7 @@ exports[`Activity should display the relevant context for the next scheduled cal
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -1915,7 +1915,7 @@ exports[`Activity should display the relevant context for the next scheduled cal
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -1925,6 +1925,7 @@ exports[`Activity should display the relevant context for the next scheduled cal
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -1988,8 +1989,7 @@ exports[`Activity should display the relevant context for the next scheduled cal
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -2001,7 +2001,7 @@ exports[`Activity should display the relevant context for the next scheduled cal
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -2011,6 +2011,7 @@ exports[`Activity should display the relevant context for the next scheduled cal
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -2074,8 +2075,7 @@ exports[`Activity should display the relevant context for the next scheduled cal
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -2087,7 +2087,7 @@ exports[`Activity should display the relevant context for the next scheduled cal
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -2097,6 +2097,7 @@ exports[`Activity should display the relevant context for the next scheduled cal
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -2160,8 +2161,7 @@ exports[`Activity should display the relevant context for the next scheduled cal
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -2173,7 +2173,7 @@ exports[`Activity should display the relevant context for the next scheduled cal
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -2183,6 +2183,7 @@ exports[`Activity should display the relevant context for the next scheduled cal
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -2246,8 +2247,7 @@ exports[`Activity should display the relevant context for the next scheduled cal
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -2520,7 +2520,7 @@ exports[`Activity should not try display a poster if none is given 1`] = `
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -2530,6 +2530,7 @@ exports[`Activity should not try display a poster if none is given 1`] = `
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -2593,8 +2594,7 @@ exports[`Activity should not try display a poster if none is given 1`] = `
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -2606,7 +2606,7 @@ exports[`Activity should not try display a poster if none is given 1`] = `
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -2616,6 +2616,7 @@ exports[`Activity should not try display a poster if none is given 1`] = `
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -2679,8 +2680,7 @@ exports[`Activity should not try display a poster if none is given 1`] = `
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -2692,7 +2692,7 @@ exports[`Activity should not try display a poster if none is given 1`] = `
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -2702,6 +2702,7 @@ exports[`Activity should not try display a poster if none is given 1`] = `
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -2765,8 +2766,7 @@ exports[`Activity should not try display a poster if none is given 1`] = `
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -2778,7 +2778,7 @@ exports[`Activity should not try display a poster if none is given 1`] = `
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -2788,6 +2788,7 @@ exports[`Activity should not try display a poster if none is given 1`] = `
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -2851,8 +2852,7 @@ exports[`Activity should not try display a poster if none is given 1`] = `
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -2864,7 +2864,7 @@ exports[`Activity should not try display a poster if none is given 1`] = `
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -2874,6 +2874,7 @@ exports[`Activity should not try display a poster if none is given 1`] = `
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -2937,8 +2938,7 @@ exports[`Activity should not try display a poster if none is given 1`] = `
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -2950,7 +2950,7 @@ exports[`Activity should not try display a poster if none is given 1`] = `
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -2960,6 +2960,7 @@ exports[`Activity should not try display a poster if none is given 1`] = `
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -3023,8 +3024,7 @@ exports[`Activity should not try display a poster if none is given 1`] = `
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -3296,7 +3296,7 @@ exports[`Activity should render 1`] = `
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -3306,6 +3306,7 @@ exports[`Activity should render 1`] = `
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -3369,8 +3370,7 @@ exports[`Activity should render 1`] = `
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -3382,7 +3382,7 @@ exports[`Activity should render 1`] = `
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -3392,6 +3392,7 @@ exports[`Activity should render 1`] = `
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -3455,8 +3456,7 @@ exports[`Activity should render 1`] = `
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -3468,7 +3468,7 @@ exports[`Activity should render 1`] = `
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -3478,6 +3478,7 @@ exports[`Activity should render 1`] = `
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -3541,8 +3542,7 @@ exports[`Activity should render 1`] = `
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -3554,7 +3554,7 @@ exports[`Activity should render 1`] = `
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -3564,6 +3564,7 @@ exports[`Activity should render 1`] = `
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -3627,8 +3628,7 @@ exports[`Activity should render 1`] = `
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -3640,7 +3640,7 @@ exports[`Activity should render 1`] = `
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -3650,6 +3650,7 @@ exports[`Activity should render 1`] = `
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -3713,8 +3714,7 @@ exports[`Activity should render 1`] = `
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]
@@ -3726,7 +3726,7 @@ exports[`Activity should render 1`] = `
     <View
       style={
         Object {
-          "paddingBottom": 29,
+          "marginBottom": 29,
         }
       }>
       <View
@@ -3736,6 +3736,7 @@ exports[`Activity should render 1`] = `
             "borderColor": "#dfe5e6",
             "height": 72,
             "justifyContent": "center",
+            "marginBottom": 12,
             "paddingLeft": 24,
             "paddingRight": 24,
           }
@@ -3799,8 +3800,7 @@ exports[`Activity should render 1`] = `
               },
               Object {
                 "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
+                "marginBottom": 12,
                 "textAlign": "left",
               },
             ]

--- a/src/views/Activity/styles.js
+++ b/src/views/Activity/styles.js
@@ -67,7 +67,7 @@ export default StyleSheet.create({
     fontWeight: FONT_WEIGHT.BOLD,
   },
   section: {
-    paddingBottom: 29,
+    marginBottom: 29,
   },
   sectionHeader: {
     paddingLeft: 24,
@@ -76,6 +76,7 @@ export default StyleSheet.create({
     backgroundColor: colors.ACTIVITY_SECTION_HEADER_BG,
     borderColor: colors.ACTIVITY_SECTION_HEADER_BORDER,
     justifyContent: 'center',
+    marginBottom: 12,
   },
   sectionIcon: {
     width: 40,

--- a/src/views/CallNoteDetail/__tests__/__snapshots__/CallNoteDetail-tests.js.snap
+++ b/src/views/CallNoteDetail/__tests__/__snapshots__/CallNoteDetail-tests.js.snap
@@ -120,46 +120,44 @@ exports[`CallNoteDetail should exclude the activity icon if it does not exist 1`
         </Text>
       </View>
       <View
-        style={
-          Array [
+        style={Object {}}>
+        <View
+          style={
             Object {
-              "flex": 1,
-            },
-            Object {
+              "alignItems": "center",
               "flex": 1,
               "flexDirection": "row",
-            },
-          ]
-        }>
-        <Text
-          accessible={true}
-          allowFontScaling={true}
-          ellipsizeMode="tail"
-          style={
-            Array [
-              Object {
-                "color": "#003035",
-                "fontFamily": "Brandon Text",
-                "fontSize": 13,
-                "textAlign": "center",
-              },
+            }
+          }>
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
               Array [
                 Object {
-                  "fontSize": 18,
-                  "paddingBottom": 12,
-                  "paddingTop": 18,
-                  "textAlign": "left",
+                  "color": "#003035",
+                  "fontFamily": "Brandon Text",
+                  "fontSize": 13,
+                  "textAlign": "center",
                 },
-                Object {
-                  "flex": 1,
-                  "paddingBottom": 0,
-                  "paddingTop": 0,
-                },
-              ],
-            ]
-          }>
-          raaar
-        </Text>
+                Array [
+                  Object {
+                    "fontSize": 18,
+                    "marginBottom": 12,
+                    "textAlign": "left",
+                  },
+                  Object {
+                    "flex": 1,
+                    "paddingBottom": 0,
+                    "paddingTop": 0,
+                  },
+                ],
+              ]
+            }>
+            raaar
+          </Text>
+        </View>
       </View>
     </View>
     <View
@@ -203,28 +201,30 @@ exports[`CallNoteDetail should exclude the activity icon if it does not exist 1`
           YOUR REFLECTIONS
         </Text>
       </View>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Array [
-            Object {
-              "color": "#003035",
-              "fontFamily": "Brandon Text",
-              "fontSize": 13,
-              "textAlign": "center",
-            },
-            Object {
-              "fontSize": 18,
-              "paddingBottom": 12,
-              "paddingTop": 18,
-              "textAlign": "left",
-            },
-          ]
-        }>
-        It went well
-      </Text>
+      <View
+        style={Object {}}>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "#003035",
+                "fontFamily": "Brandon Text",
+                "fontSize": 13,
+                "textAlign": "center",
+              },
+              Object {
+                "fontSize": 18,
+                "marginBottom": 12,
+                "textAlign": "left",
+              },
+            ]
+          }>
+          It went well
+        </Text>
+      </View>
     </View>
     <View
       style={
@@ -268,11 +268,7 @@ exports[`CallNoteDetail should exclude the activity icon if it does not exist 1`
         </Text>
       </View>
       <View
-        style={
-          Object {
-            "flex": 1,
-          }
-        }>
+        style={Object {}}>
         <Image
           source={1}
           style={
@@ -324,11 +320,7 @@ exports[`CallNoteDetail should exclude the activity icon if it does not exist 1`
         </Text>
       </View>
       <View
-        style={
-          Object {
-            "flex": 1,
-          }
-        }>
+        style={Object {}}>
         <Image
           source={1}
           style={
@@ -379,31 +371,33 @@ exports[`CallNoteDetail should exclude the activity icon if it does not exist 1`
           HELPFULNESS OF ACTIVITY
         </Text>
       </View>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Array [
-            Object {
-              "color": "#003035",
-              "fontFamily": "Brandon Text",
-              "fontSize": 13,
-              "textAlign": "center",
-            },
+      <View
+        style={Object {}}>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
             Array [
               Object {
-                "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
-                "textAlign": "left",
-              },
-              Object {
+                "color": "#003035",
+                "fontFamily": "Brandon Text",
+                "fontSize": 13,
                 "textAlign": "center",
               },
-            ],
-          ]
-        } />
+              Array [
+                Object {
+                  "fontSize": 18,
+                  "marginBottom": 12,
+                  "textAlign": "left",
+                },
+                Object {
+                  "textAlign": "center",
+                },
+              ],
+            ]
+          } />
+      </View>
     </View>
   </ScrollView>
 </View>
@@ -530,28 +524,30 @@ exports[`CallNoteDetail should exclude the activity views if they are undefined 
           YOUR REFLECTIONS
         </Text>
       </View>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Array [
-            Object {
-              "color": "#003035",
-              "fontFamily": "Brandon Text",
-              "fontSize": 13,
-              "textAlign": "center",
-            },
-            Object {
-              "fontSize": 18,
-              "paddingBottom": 12,
-              "paddingTop": 18,
-              "textAlign": "left",
-            },
-          ]
-        }>
-        It went well
-      </Text>
+      <View
+        style={Object {}}>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "#003035",
+                "fontFamily": "Brandon Text",
+                "fontSize": 13,
+                "textAlign": "center",
+              },
+              Object {
+                "fontSize": 18,
+                "marginBottom": 12,
+                "textAlign": "left",
+              },
+            ]
+          }>
+          It went well
+        </Text>
+      </View>
     </View>
     <View
       style={
@@ -595,11 +591,7 @@ exports[`CallNoteDetail should exclude the activity views if they are undefined 
         </Text>
       </View>
       <View
-        style={
-          Object {
-            "flex": 1,
-          }
-        }>
+        style={Object {}}>
         <Image
           source={1}
           style={
@@ -650,31 +642,33 @@ exports[`CallNoteDetail should exclude the activity views if they are undefined 
           HELPFULNESS OF ACTIVITY
         </Text>
       </View>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Array [
-            Object {
-              "color": "#003035",
-              "fontFamily": "Brandon Text",
-              "fontSize": 13,
-              "textAlign": "center",
-            },
+      <View
+        style={Object {}}>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
             Array [
               Object {
-                "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
-                "textAlign": "left",
-              },
-              Object {
+                "color": "#003035",
+                "fontFamily": "Brandon Text",
+                "fontSize": 13,
                 "textAlign": "center",
               },
-            ],
-          ]
-        } />
+              Array [
+                Object {
+                  "fontSize": 18,
+                  "marginBottom": 12,
+                  "textAlign": "left",
+                },
+                Object {
+                  "textAlign": "center",
+                },
+              ],
+            ]
+          } />
+      </View>
     </View>
   </ScrollView>
 </View>
@@ -802,46 +796,44 @@ exports[`CallNoteDetail should render 1`] = `
         </Text>
       </View>
       <View
-        style={
-          Array [
+        style={Object {}}>
+        <View
+          style={
             Object {
-              "flex": 1,
-            },
-            Object {
+              "alignItems": "center",
               "flex": 1,
               "flexDirection": "row",
-            },
-          ]
-        }>
-        <Text
-          accessible={true}
-          allowFontScaling={true}
-          ellipsizeMode="tail"
-          style={
-            Array [
-              Object {
-                "color": "#003035",
-                "fontFamily": "Brandon Text",
-                "fontSize": 13,
-                "textAlign": "center",
-              },
+            }
+          }>
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
               Array [
                 Object {
-                  "fontSize": 18,
-                  "paddingBottom": 12,
-                  "paddingTop": 18,
-                  "textAlign": "left",
+                  "color": "#003035",
+                  "fontFamily": "Brandon Text",
+                  "fontSize": 13,
+                  "textAlign": "center",
                 },
-                Object {
-                  "flex": 1,
-                  "paddingBottom": 0,
-                  "paddingTop": 0,
-                },
-              ],
-            ]
-          }>
-          raaar
-        </Text>
+                Array [
+                  Object {
+                    "fontSize": 18,
+                    "marginBottom": 12,
+                    "textAlign": "left",
+                  },
+                  Object {
+                    "flex": 1,
+                    "paddingBottom": 0,
+                    "paddingTop": 0,
+                  },
+                ],
+              ]
+            }>
+            raaar
+          </Text>
+        </View>
       </View>
     </View>
     <View
@@ -885,28 +877,30 @@ exports[`CallNoteDetail should render 1`] = `
           YOUR REFLECTIONS
         </Text>
       </View>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Array [
-            Object {
-              "color": "#003035",
-              "fontFamily": "Brandon Text",
-              "fontSize": 13,
-              "textAlign": "center",
-            },
-            Object {
-              "fontSize": 18,
-              "paddingBottom": 12,
-              "paddingTop": 18,
-              "textAlign": "left",
-            },
-          ]
-        }>
-        It went well
-      </Text>
+      <View
+        style={Object {}}>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "#003035",
+                "fontFamily": "Brandon Text",
+                "fontSize": 13,
+                "textAlign": "center",
+              },
+              Object {
+                "fontSize": 18,
+                "marginBottom": 12,
+                "textAlign": "left",
+              },
+            ]
+          }>
+          It went well
+        </Text>
+      </View>
     </View>
     <View
       style={
@@ -950,11 +944,7 @@ exports[`CallNoteDetail should render 1`] = `
         </Text>
       </View>
       <View
-        style={
-          Object {
-            "flex": 1,
-          }
-        }>
+        style={Object {}}>
         <Image
           source={1}
           style={
@@ -1006,11 +996,7 @@ exports[`CallNoteDetail should render 1`] = `
         </Text>
       </View>
       <View
-        style={
-          Object {
-            "flex": 1,
-          }
-        }>
+        style={Object {}}>
         <Image
           source={1}
           style={
@@ -1061,31 +1047,33 @@ exports[`CallNoteDetail should render 1`] = `
           HELPFULNESS OF ACTIVITY
         </Text>
       </View>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Array [
-            Object {
-              "color": "#003035",
-              "fontFamily": "Brandon Text",
-              "fontSize": 13,
-              "textAlign": "center",
-            },
+      <View
+        style={Object {}}>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
             Array [
               Object {
-                "fontSize": 18,
-                "paddingBottom": 12,
-                "paddingTop": 18,
-                "textAlign": "left",
-              },
-              Object {
+                "color": "#003035",
+                "fontFamily": "Brandon Text",
+                "fontSize": 13,
                 "textAlign": "center",
               },
-            ],
-          ]
-        } />
+              Array [
+                Object {
+                  "fontSize": 18,
+                  "marginBottom": 12,
+                  "textAlign": "left",
+                },
+                Object {
+                  "textAlign": "center",
+                },
+              ],
+            ]
+          } />
+      </View>
     </View>
   </ScrollView>
 </View>

--- a/src/views/CallNoteDetail/__tests__/__snapshots__/CallNoteDetail-tests.js.snap
+++ b/src/views/CallNoteDetail/__tests__/__snapshots__/CallNoteDetail-tests.js.snap
@@ -90,6 +90,7 @@ exports[`CallNoteDetail should exclude the activity icon if it does not exist 1`
             "borderBottomWidth": 0.5,
             "borderColor": "#dfe5e6",
             "borderStyle": "solid",
+            "marginBottom": 18,
             "paddingBottom": 19,
           }
         }>
@@ -122,9 +123,10 @@ exports[`CallNoteDetail should exclude the activity icon if it does not exist 1`
         style={
           Array [
             Object {
-              "marginTop": 18,
+              "flex": 1,
             },
             Object {
+              "flex": 1,
               "flexDirection": "row",
             },
           ]
@@ -149,7 +151,7 @@ exports[`CallNoteDetail should exclude the activity icon if it does not exist 1`
                   "textAlign": "left",
                 },
                 Object {
-                  "alignSelf": "center",
+                  "flex": 1,
                   "paddingBottom": 0,
                   "paddingTop": 0,
                 },
@@ -172,6 +174,7 @@ exports[`CallNoteDetail should exclude the activity icon if it does not exist 1`
             "borderBottomWidth": 0.5,
             "borderColor": "#dfe5e6",
             "borderStyle": "solid",
+            "marginBottom": 18,
             "paddingBottom": 19,
           }
         }>
@@ -235,6 +238,7 @@ exports[`CallNoteDetail should exclude the activity icon if it does not exist 1`
             "borderBottomWidth": 0.5,
             "borderColor": "#dfe5e6",
             "borderStyle": "solid",
+            "marginBottom": 18,
             "paddingBottom": 19,
           }
         }>
@@ -266,7 +270,7 @@ exports[`CallNoteDetail should exclude the activity icon if it does not exist 1`
       <View
         style={
           Object {
-            "marginTop": 18,
+            "flex": 1,
           }
         }>
         <Image
@@ -290,6 +294,7 @@ exports[`CallNoteDetail should exclude the activity icon if it does not exist 1`
             "borderBottomWidth": 0.5,
             "borderColor": "#dfe5e6",
             "borderStyle": "solid",
+            "marginBottom": 18,
             "paddingBottom": 19,
           }
         }>
@@ -321,7 +326,7 @@ exports[`CallNoteDetail should exclude the activity icon if it does not exist 1`
       <View
         style={
           Object {
-            "marginTop": 18,
+            "flex": 1,
           }
         }>
         <Image
@@ -345,6 +350,7 @@ exports[`CallNoteDetail should exclude the activity icon if it does not exist 1`
             "borderBottomWidth": 0.5,
             "borderColor": "#dfe5e6",
             "borderStyle": "solid",
+            "marginBottom": 18,
             "paddingBottom": 19,
           }
         }>
@@ -495,6 +501,7 @@ exports[`CallNoteDetail should exclude the activity views if they are undefined 
             "borderBottomWidth": 0.5,
             "borderColor": "#dfe5e6",
             "borderStyle": "solid",
+            "marginBottom": 18,
             "paddingBottom": 19,
           }
         }>
@@ -558,6 +565,7 @@ exports[`CallNoteDetail should exclude the activity views if they are undefined 
             "borderBottomWidth": 0.5,
             "borderColor": "#dfe5e6",
             "borderStyle": "solid",
+            "marginBottom": 18,
             "paddingBottom": 19,
           }
         }>
@@ -589,7 +597,7 @@ exports[`CallNoteDetail should exclude the activity views if they are undefined 
       <View
         style={
           Object {
-            "marginTop": 18,
+            "flex": 1,
           }
         }>
         <Image
@@ -613,6 +621,7 @@ exports[`CallNoteDetail should exclude the activity views if they are undefined 
             "borderBottomWidth": 0.5,
             "borderColor": "#dfe5e6",
             "borderStyle": "solid",
+            "marginBottom": 18,
             "paddingBottom": 19,
           }
         }>
@@ -763,6 +772,7 @@ exports[`CallNoteDetail should render 1`] = `
             "borderBottomWidth": 0.5,
             "borderColor": "#dfe5e6",
             "borderStyle": "solid",
+            "marginBottom": 18,
             "paddingBottom": 19,
           }
         }>
@@ -795,9 +805,10 @@ exports[`CallNoteDetail should render 1`] = `
         style={
           Array [
             Object {
-              "marginTop": 18,
+              "flex": 1,
             },
             Object {
+              "flex": 1,
               "flexDirection": "row",
             },
           ]
@@ -822,7 +833,7 @@ exports[`CallNoteDetail should render 1`] = `
                   "textAlign": "left",
                 },
                 Object {
-                  "alignSelf": "center",
+                  "flex": 1,
                   "paddingBottom": 0,
                   "paddingTop": 0,
                 },
@@ -845,6 +856,7 @@ exports[`CallNoteDetail should render 1`] = `
             "borderBottomWidth": 0.5,
             "borderColor": "#dfe5e6",
             "borderStyle": "solid",
+            "marginBottom": 18,
             "paddingBottom": 19,
           }
         }>
@@ -908,6 +920,7 @@ exports[`CallNoteDetail should render 1`] = `
             "borderBottomWidth": 0.5,
             "borderColor": "#dfe5e6",
             "borderStyle": "solid",
+            "marginBottom": 18,
             "paddingBottom": 19,
           }
         }>
@@ -939,7 +952,7 @@ exports[`CallNoteDetail should render 1`] = `
       <View
         style={
           Object {
-            "marginTop": 18,
+            "flex": 1,
           }
         }>
         <Image
@@ -963,6 +976,7 @@ exports[`CallNoteDetail should render 1`] = `
             "borderBottomWidth": 0.5,
             "borderColor": "#dfe5e6",
             "borderStyle": "solid",
+            "marginBottom": 18,
             "paddingBottom": 19,
           }
         }>
@@ -994,7 +1008,7 @@ exports[`CallNoteDetail should render 1`] = `
       <View
         style={
           Object {
-            "marginTop": 18,
+            "flex": 1,
           }
         }>
         <Image
@@ -1018,6 +1032,7 @@ exports[`CallNoteDetail should render 1`] = `
             "borderBottomWidth": 0.5,
             "borderColor": "#dfe5e6",
             "borderStyle": "solid",
+            "marginBottom": 18,
             "paddingBottom": 19,
           }
         }>

--- a/src/views/CallNoteDetail/index.js
+++ b/src/views/CallNoteDetail/index.js
@@ -56,26 +56,31 @@ const CallNoteDetail = ({
         <View style={styles.section}>
           <Title>Discussion With Activity</Title>
 
-          <View style={[styles.sectionBody, styles.sectionBodyActivity]}>
-            {
-              activity.icon.exists() && <Image
-                source={activity.icon.resize(72, 72).toSource()}
-                style={styles.activityImage}
-              />
-            }
+          <View style={styles.sectionBody}>
+            <View style={styles.sectionBodyActivityItems}>
+              {
+                activity.icon.exists() && <Image
+                  source={activity.icon.resize(72, 72).toSource()}
+                  style={styles.activityImage}
+                />
+              }
 
-            <Text style={[Text.types.paragraph, styles.activityObjective]}>
-              {activity.objective}
-            </Text>
+              <Text style={[Text.types.paragraph, styles.activityObjective]}>
+                {activity.objective}
+              </Text>
+            </View>
           </View>
         </View>
       )}
 
       <View style={styles.section}>
         <Title>Your Reflections</Title>
-        <Text style={Text.types.paragraph}>
-          {reflection}
-        </Text>
+
+        <View style={styles.sectionBody}>
+          <Text style={Text.types.paragraph}>
+            {reflection}
+          </Text>
+        </View>
       </View>
 
       <View style={styles.section}>
@@ -108,9 +113,12 @@ const CallNoteDetail = ({
 
       <View style={styles.section}>
         <Title>Helpfulness of Activity</Title>
-        <Text style={[Text.types.paragraph, styles.activityHelpfulText]}>
-          {constants.RATING_ITEMS[activityHelpful]}
-        </Text>
+
+        <View style={styles.sectionBody}>
+          <Text style={[Text.types.paragraph, styles.activityHelpfulText]}>
+            {constants.RATING_ITEMS[activityHelpful]}
+          </Text>
+        </View>
       </View>
     </ScrollView>
   </BaseView>

--- a/src/views/CallNoteDetail/styles.js
+++ b/src/views/CallNoteDetail/styles.js
@@ -16,18 +16,17 @@ export default StyleSheet.create({
     marginBottom: 45,
   },
   sectionBody: {
-    flex: 1,
   },
-  sectionBodyActivity: {
+  sectionBodyActivityItems: {
     flex: 1,
     flexDirection: 'row',
+    alignItems: 'center',
   },
   activityImage: {
     width: 72,
     height: 72,
     marginRight: 16,
-    alignSelf: 'center',
-    marginBottom: 45,
+    marginBottom: 12,
   },
   menteeStateImage: {
     alignSelf: 'center',

--- a/src/views/CallNoteDetail/styles.js
+++ b/src/views/CallNoteDetail/styles.js
@@ -10,20 +10,24 @@ export default StyleSheet.create({
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderStyle: 'solid',
     paddingBottom: 19,
+    marginBottom: 18,
   },
   section: {
     marginBottom: 45,
   },
   sectionBody: {
-    marginTop: 18,
+    flex: 1,
   },
   sectionBodyActivity: {
+    flex: 1,
     flexDirection: 'row',
   },
   activityImage: {
     width: 72,
     height: 72,
     marginRight: 16,
+    alignSelf: 'center',
+    marginBottom: 45,
   },
   menteeStateImage: {
     alignSelf: 'center',
@@ -32,9 +36,9 @@ export default StyleSheet.create({
     alignSelf: 'center',
   },
   activityObjective: {
+    flex: 1,
     paddingTop: 0,
     paddingBottom: 0,
-    alignSelf: 'center',
   },
   activityHelpfulText: {
     textAlign: 'center',

--- a/src/views/CallNoteSteps/Completed/__tests__/__snapshots__/Completed-test.js.snap
+++ b/src/views/CallNoteSteps/Completed/__tests__/__snapshots__/Completed-test.js.snap
@@ -96,7 +96,7 @@ exports[`Completed should render 1`] = `
         <View
           style={
             Object {
-              "paddingBottom": 29,
+              "marginBottom": 29,
             }
           }>
           <View
@@ -106,6 +106,7 @@ exports[`Completed should render 1`] = `
                 "borderColor": "#dfe5e6",
                 "height": 72,
                 "justifyContent": "center",
+                "marginBottom": 12,
                 "paddingLeft": 24,
                 "paddingRight": 24,
               }
@@ -169,8 +170,7 @@ exports[`Completed should render 1`] = `
                   },
                   Object {
                     "fontSize": 18,
-                    "paddingBottom": 12,
-                    "paddingTop": 18,
+                    "marginBottom": 12,
                     "textAlign": "left",
                   },
                 ]

--- a/src/views/CategoryAbout/__tests__/__snapshots__/CategoryAbout-test.js.snap
+++ b/src/views/CategoryAbout/__tests__/__snapshots__/CategoryAbout-test.js.snap
@@ -33,6 +33,7 @@ exports[`CategoryAbout should render 1`] = `
         Object {
           "borderBottomColor": "#dfe5e6",
           "borderBottomWidth": 1,
+          "marginBottom": 12,
           "paddingBottom": 11,
         }
       }>
@@ -75,8 +76,7 @@ exports[`CategoryAbout should render 1`] = `
           },
           Object {
             "fontSize": 18,
-            "paddingBottom": 12,
-            "paddingTop": 18,
+            "marginBottom": 12,
             "textAlign": "left",
           },
         ]
@@ -95,6 +95,7 @@ exports[`CategoryAbout should render 1`] = `
         Object {
           "borderBottomColor": "#dfe5e6",
           "borderBottomWidth": 1,
+          "marginBottom": 12,
           "paddingBottom": 11,
         }
       }>
@@ -137,8 +138,7 @@ exports[`CategoryAbout should render 1`] = `
           },
           Object {
             "fontSize": 18,
-            "paddingBottom": 12,
-            "paddingTop": 18,
+            "marginBottom": 12,
             "textAlign": "left",
           },
         ]


### PR DESCRIPTION
At the moment, if the content for "discussion with activity" section is long enough, it trails off the screen instead of wrapping.

Ended up including some adjustment and alignment fixes for the same screen, which had some implications for other screens using the same styles.