### PR TITLE
Add dev entry point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ android/app/google-services.json
 .env.qa
 .env.prd
 src/config/dev.js
+src/app.dev.js
 
 *.keystore
 secrets.tar

--- a/README.md
+++ b/README.md
@@ -80,3 +80,5 @@ git flow release finish -p <version>
 ## Development Configuration
 
 Development-specific configuration can be defined by adding a `src/config/dev.js` module. See `src/config/dev.example.js` for an example.
+
+A development-specific entry point to the app can be added by defining `src/app.dev.js` and setting `USE_DEV_APP` to `true` in `src/config/dev.js`. This will override the default entry point, `src/app.js`.

--- a/README.md
+++ b/README.md
@@ -20,13 +20,45 @@ to install our projects dependencies.
 Starts React Native's packager, builds the Android application and runs it
 on your _Android Virtual Device._
 
-## Debugging
-
-`> npm run logs`
-
 ## Tests
 
-`> npm test`
+To run all tests:
+
+```
+npm test
+```
+
+To test on file changes:
+
+```
+npm test:watch
+```
+
+To run a particular test module:
+
+```
+npm test -- path/to/test/module.js
+```
+
+## Development
+
+For inspecting log output:
+
+```
+npm run logs
+```
+
+For keeping the js bundler running during development:
+
+```
+npm start
+```
+
+## Development Configuration
+
+Development-specific configuration can be defined by adding a `src/config/dev.js` module. See `src/config/dev.example.js` for an example.
+
+A development-specific entry point to the app can be added by defining `src/app.dev.js` and setting `USE_DEV_APP` to `true` in `src/config/dev.js`. This will override the default entry point, `src/app.js`.
 
 
 ## Automatic Builds
@@ -72,13 +104,7 @@ A `dev` suffix should be used for dev releases, starting at `-dev`, followed by 
 **Note:** This process should only be followed when the current changes on `develop` are to be merged into `master` and considered the new **production-ready** code.
 
 ```
-git flow release start <version>
-./utils/version.sh <version>
-git flow release finish -p <version>
+> git flow release start <version>
+> ./utils/version.sh <version>
+> git flow release finish -p <version>
 ```
-
-## Development Configuration
-
-Development-specific configuration can be defined by adding a `src/config/dev.js` module. See `src/config/dev.example.js` for an example.
-
-A development-specific entry point to the app can be added by defining `src/app.dev.js` and setting `USE_DEV_APP` to `true` in `src/config/dev.js`. This will override the default entry point, `src/app.js`.

--- a/index.android.js
+++ b/index.android.js
@@ -1,6 +1,10 @@
 import React from 'react';
-import MentorshipApp from 'src/app';
 import { AppRegistry } from 'react-native';
+import config from 'src/config';
 
 
-AppRegistry.registerComponent('app', () => () => <MentorshipApp />);
+const EntryComponent = global.__DEV__ && config.USE_DEV_APP
+  ? require('src/app.dev').default
+  : require('src/app').default;
+
+AppRegistry.registerComponent('app', () => () => <EntryComponent />);

--- a/src/config/base.js
+++ b/src/config/base.js
@@ -2,4 +2,5 @@ export default {
   API_PATH: '/mentor',
   API_BASE_URL: null,
   SENTRY_URL: null,
+  USE_DEV_APP: false,
 };

--- a/src/config/dev.example.js
+++ b/src/config/dev.example.js
@@ -1,3 +1,4 @@
 export default {
   API_BASE_URL: 'http://127.0.0.1:8000',
+  USE_DEV_APP: false,
 };


### PR DESCRIPTION
When building a view it is often useful to render it in isolation rather than navigate to it after every reload. We've been modifying `index.android.js` instead, but this is problematic: it is easy to accidentally commit changes to this file made for testing things in development, for example.

This PR makes that possible by adding a config option. If `USE_DEV_APP` is set to `true` (which can be configured in `src/config/dev.js`), and we are in development mode (`__DEV__ === true`), this will use `src/app.dev.js` as the entry point for the app instead of `src/app.js`.

If one just wanted to add some side effects for testing something in development, this would also be possible: `src/app.dev` would simply need to export `src/app.js`'s default as its default.