### PR TITLE
Debounce form steps

### DIFF
--- a/src/components/Pagination/__tests__/Pagination-test.js
+++ b/src/components/Pagination/__tests__/Pagination-test.js
@@ -4,7 +4,7 @@ import Pagination from 'src/components/Pagination';
 import { uidEquals } from 'app/scripts/helpers';
 
 
-describe('Button', () => {
+describe('Pagination', () => {
   const createComponent = (props = {}) => (
       <Pagination
         onBackPress={noop}

--- a/src/components/Pagination/__tests__/__snapshots__/Pagination-test.js.snap
+++ b/src/components/Pagination/__tests__/__snapshots__/Pagination-test.js.snap
@@ -1,4 +1,4 @@
-exports[`Button should disable its done button if disabled is true 1`] = `
+exports[`Pagination should disable its done button if disabled is true 1`] = `
 <View
   style={
     Object {
@@ -155,7 +155,7 @@ exports[`Button should disable its done button if disabled is true 1`] = `
 </View>
 `;
 
-exports[`Button should disable its next button if disabled is true 1`] = `
+exports[`Pagination should disable its next button if disabled is true 1`] = `
 <View
   style={
     Object {
@@ -312,7 +312,7 @@ exports[`Button should disable its next button if disabled is true 1`] = `
 </View>
 `;
 
-exports[`Button should render a done button if last is true 1`] = `
+exports[`Pagination should render a done button if last is true 1`] = `
 <View
   style={
     Object {
@@ -462,7 +462,7 @@ exports[`Button should render a done button if last is true 1`] = `
 </View>
 `;
 
-exports[`Button should render props correctly 1`] = `
+exports[`Pagination should render props correctly 1`] = `
 <View
   style={
     Object {
@@ -612,7 +612,7 @@ exports[`Button should render props correctly 1`] = `
 </View>
 `;
 
-exports[`Button should support disabling its back button 1`] = `
+exports[`Pagination should support disabling its back button 1`] = `
 <View
   style={
     Object {

--- a/src/components/Pagination/index.js
+++ b/src/components/Pagination/index.js
@@ -6,7 +6,7 @@ import Button from 'src/components/Button';
 import Icon from 'src/components/Icon';
 import styles from './styles';
 
-import { PAGINATION_DEBOUNCE_INTERVAL } from 'src/constants/behavior';
+import { PAGING_DEBOUNCE_INTERVAL } from 'src/constants/behavior';
 
 
 const debouncePager = fn => debounce(fn, PAGING_DEBOUNCE_INTERVAL, {

--- a/src/components/Pagination/index.js
+++ b/src/components/Pagination/index.js
@@ -1,36 +1,81 @@
-import { noop } from 'lodash';
-import React, { PropTypes } from 'react';
+import { noop, debounce } from 'lodash';
+import React, { PropTypes, Component } from 'react';
 import { View } from 'react-native';
+
 import Button from 'src/components/Button';
 import Icon from 'src/components/Icon';
 import styles from './styles';
 
+import { PAGINATION_DEBOUNCE_INTERVAL } from 'src/constants/behavior';
 
-const Pagination = ({
-  onBackPress = noop,
-  onNextPress = noop,
-  onDonePress = noop,
-  backDisabled,
-  disabled,
-  last = false,
-}) => (
-  <View style={styles.container}>
-    <Button
-      uid="back"
-      theme={Button.themes.transparent}
-      layout={[Button.layouts.inline, styles.backButtonLayout]}
-      onPress={onBackPress}
-      disabled={backDisabled}
-    >
-      <Icon type={Icon.types.backOrange} />
-    </Button>
-    {
-      !last
+
+const debouncePager = fn => debounce(fn, PAGING_DEBOUNCE_INTERVAL, {
+  leading: true,
+  trailing: false,
+});
+
+
+class Pagination extends Component {
+  static defaultProps = {
+    onBackPress: noop,
+    onNextPress: noop,
+    onDonePress: noop,
+    last: false,
+  }
+
+  static propTypes = {
+    onBackPress: PropTypes.func,
+    onNextPress: PropTypes.func,
+    onDonePress: PropTypes.func,
+    backDisabled: PropTypes.bool,
+    disabled: PropTypes.bool,
+    last: PropTypes.bool,
+  }
+
+  constructor(...args) {
+    super(...args);
+    this.onDonePress = debouncePager(this.onDonePress.bind(this));
+    this.onNextPress = debouncePager(this.onNextPress.bind(this));
+    this.onBackPress = debouncePager(this.onBackPress.bind(this));
+  }
+
+  onDonePress() {
+    this.props.onDonePress();
+  }
+
+  onNextPress() {
+    this.props.onNextPress();
+  }
+
+  onBackPress() {
+    this.props.onBackPress();
+  }
+
+  render() {
+    const {
+      backDisabled,
+      disabled,
+      last,
+    } = this.props;
+
+    return (
+      <View style={styles.container}>
+        <Button
+          uid="back"
+          theme={Button.themes.transparent}
+          layout={[Button.layouts.inline, styles.backButtonLayout]}
+          onPress={this.onBackPress}
+          disabled={backDisabled}
+        >
+          <Icon type={Icon.types.backOrange} />
+        </Button>
+        {
+        !last
         ? <Button
           uid="next"
           theme={Button.themes.transparent}
           layout={[Button.layouts.inline, styles.nextButtonLayout]}
-          onPress={onNextPress}
+          onPress={this.onNextPress}
           disabled={disabled}
         >
           NEXT
@@ -39,24 +84,16 @@ const Pagination = ({
           uid="done"
           theme={Button.themes.transparent}
           layout={[Button.layouts.inline, styles.nextButtonLayout]}
-          onPress={onDonePress}
+          onPress={this.onDonePress}
           disabled={disabled}
         >
           DONE
         </Button>
-    }
-  </View>
-);
-
-
-Pagination.propTypes = {
-  onBackPress: PropTypes.func,
-  onNextPress: PropTypes.func,
-  onDonePress: PropTypes.func,
-  backDisabled: PropTypes.bool,
-  disabled: PropTypes.bool,
-  last: PropTypes.bool,
-};
+        }
+      </View>
+    );
+  }
+}
 
 
 export default Pagination;

--- a/src/components/Stepper/index.js
+++ b/src/components/Stepper/index.js
@@ -1,18 +1,9 @@
-import { range, clamp, fromPairs, debounce } from 'lodash';
+import { range, clamp, fromPairs } from 'lodash';
 import React, { Component, PropTypes } from 'react';
 import BackAndroid from 'BackAndroid';
 
 import { ProgressBar, BaseView, FormView, NavigationStack } from 'src/components';
 import { createRoute } from 'src/navigationHelpers';
-
-
-const PAGING_DEBOUNCE = 250;
-
-
-const debouncePager = fn => debounce(fn, PAGING_DEBOUNCE, {
-  leading: true,
-  trailing: false,
-});
 
 
 const Step = ({
@@ -32,8 +23,8 @@ class Stepper extends Component {
       index: 0,
     };
 
-    this.onNextPress = debouncePager(this.onNextPress.bind(this));
-    this.onBackPress = debouncePager(this.onBackPress.bind(this));
+    this.onNextPress = this.onNextPress.bind(this);
+    this.onBackPress = this.onBackPress.bind(this);
     this.onNativeBackPress = this.onNativeBackPress.bind(this);
   }
 

--- a/src/constants/behavior.js
+++ b/src/constants/behavior.js
@@ -1,0 +1,1 @@
+export const PAGING_DEBOUNCE_INTERVAL = 250;


### PR DESCRIPTION
This prevents users from moving further ahead in the stepper than they should because of tapping the next button multiple times.

@nathanbebgie ready for review